### PR TITLE
fix(ci): use java 17 runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,11 +45,11 @@ jobs:
         if: startsWith(matrix.os, 'windows')
 
       - uses: actions/checkout@v3
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
           cache: 'maven'
 
       - name: Build with Maven


### PR DESCRIPTION
Required by the spring-kafka-test library
Ref: https://github.com/quarkiverse/quarkus-kafka-streams-processor/actions/runs/7529170043/job/20492850361