### PR TITLE
fix: use java 17 for all workflows

### DIFF
--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -10,7 +10,7 @@ on:
 env:
   ECOSYSTEM_CI_REPO: quarkusio/quarkus-ecosystem-ci
   ECOSYSTEM_CI_REPO_FILE: context.yaml
-  JAVA_VERSION: 11
+  JAVA_VERSION: 17
 
   #########################
   # Repo specific setting #

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,11 +37,11 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
           cache: 'maven'
           server-id: ossrh
           server-username: MAVEN_USERNAME


### PR DESCRIPTION
We need java 17 at build time for a test dependency, this was already solved on the main build workflow but the problem was still present on releasing ones.