### PR TITLE
Add extension metadata, incl. sponsor

### DIFF
--- a/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,9 +1,18 @@
+# https://quarkus.io/version/main/guides/extension-metadata#quarkus-extension-yaml
 name: Kafka Streams Processor
-#description: Do something useful.
+description: "Easily build resilient Kafka Streams topologies based on the Processor API"
+sponsor: "Amadeus IT Group"
 metadata:
-#  keywords:
-#    - kafka-streams-processor
-#  guide: https://quarkiverse.github.io/quarkiverse-docs/kafka-streams-processor/dev/ # To create and publish this guide, see https://github.com/quarkiverse/quarkiverse/wiki#documenting-your-extension
-#  categories:
-#    - "miscellaneous"
-#  status: "preview"
+  short-name: "kafka-streams-processor"
+  keywords:
+    - "kafka"
+    - "kstreams"
+    - "kafka-streams"
+    - "streaming"
+    - "processor"
+  categories:
+    - "messaging"
+  status: "preview"
+  guide: https://docs.quarkiverse.io/quarkus-kafka-streams-processor/dev/index.html
+  config:
+    - "kafkastreamsprocessor"


### PR DESCRIPTION
Similar to https://github.com/quarkiverse/quarkus-logging-splunk/pull/238

I guess we'll be missing a PR on https://github.com/quarkusio/quarkus-extension-catalog/tree/main/extensions, so that the extension gets registered in the extension catalog https://quarkus.io/extensions