### PR TITLE
bug: reproducer for decorator issue

### DIFF
--- a/integration-tests/kafka-to-rest/src/main/java/io/quarkiverse/kafkastreamsprocessor/sample/kafkatorest/PingClientProcessor.java
+++ b/integration-tests/kafka-to-rest/src/main/java/io/quarkiverse/kafkastreamsprocessor/sample/kafkatorest/PingClientProcessor.java
@@ -28,6 +28,8 @@ import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.processor.api.RecordMetadata;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
+import io.micrometer.core.annotation.Counted;
+import io.micrometer.core.annotation.Timed;
 import io.quarkiverse.kafkastreamsprocessor.api.Processor;
 import io.quarkiverse.kafkastreamsprocessor.sample.message.PingMessage;
 import lombok.extern.slf4j.Slf4j;
@@ -44,8 +46,8 @@ public class PingClientProcessor extends ContextualProcessor<String, PingMessage
     }
 
     @Override
-    //    @Timed
-    //    @Counted(value = "processedMessageCount", description = "Total number of messages processed")
+    @Timed
+    @Counted(value = "processedMessageCount", description = "Total number of messages processed")
     public void process(Record<String, PingMessage.Ping> record) {
         Integer partition = null;
 


### PR DESCRIPTION
Enabling decorators and interceptors on a processor causes a VerifyError about invalid bytecode

```
Caused by: java.lang.VerifyError: Method expects a return value
Exception Details:
  Location:
    io/quarkiverse/kafkastreamsprocessor/sample/kafkatorest/PingClientProcessor_Subclass$$function$$1.apply(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object; @26: return
  Reason:
    Error exists in the bytecode
  Bytecode:
    0000000: 2cc0 000c b900 1001 0003 324e 2ab4 0012
    0000010: c000 142d c000 16b6 001a b1

        at io.quarkiverse.kafkastreamsprocessor.sample.kafkatorest.PingClientProcessor_Subclass.arc$initMetadata0(Unknown Source)
        at io.quarkiverse.kafkastreamsprocessor.sample.kafkatorest.PingClientProcessor_Subclass.<init>(Unknown Source)
        at io.quarkiverse.kafkastreamsprocessor.sample.kafkatorest.PingClientProcessor_Bean.doCreate(Unknown Source)
        at io.quarkiverse.kafkastreamsprocessor.sample.kafkatorest.PingClientProcessor_Bean.create(Unknown Source)
        at io.quarkiverse.kafkastreamsprocessor.sample.kafkatorest.PingClientProcessor_Bean.get(Unknown Source)
        at io.quarkiverse.kafkastreamsprocessor.sample.kafkatorest.PingClientProcessor_Bean.get(Unknown Source)
        at io.quarkus.arc.impl.InstanceImpl.getBeanInstance(InstanceImpl.java:325)

```

Refs: https://github.com/quarkusio/quarkus/issues/38236