### PR TITLE
fix(doc): correct output sink property in configuration table

### DIFF
--- a/docs/modules/ROOT/pages/includes/kafka-streams-processor-configuration-keys.adoc
+++ b/docs/modules/ROOT/pages/includes/kafka-streams-processor-configuration-keys.adoc
@@ -41,17 +41,17 @@ endif::add-copy-button-to-env-var[]
 -- a| string
 |
 
-a| [[kafka-streams-processor-configuration-keys_kafka.streams.processor-sink-topic]]`link:#kafka-streams-processor-configuration-keys_kafka.streams.processor-sink-topic[kafka.streams.processor<sink>.topic]`
+a| [[kafka-streams-processor-configuration-keys_kafkastreamsprocessor-output-sinks-sink-topic]]`link:#kafka-streams-processor-configuration-keys_kafkastreamsprocessor-output-sinks-sink-topic[kafkastreamsprocessor.output.sinks.<sink>.topic]`
 
 [.description]
 --
 The Kafka topic for outgoing messages for the given sink name.
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++KAFKA_STREAMS_PROCESSOR__sink__TOPIC+++[]
+Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_OUTPUT_SINKS__sink__TOPIC+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++KAFKA_STREAMS_PROCESSOR__sink__TOPIC+++`
+Environment variable: `+++KAFKASTREAMSPROCESSOR_OUTPUT_SINKS__sink__TOPIC+++`
 endif::add-copy-button-to-env-var[]
 --| string
 |

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -152,7 +152,7 @@ In Kafka Streams Processor the following configuration keys are required:
 
 * `link:#kafka-streams-processor-configuration-keys_kafkastreamsprocessor.input.topic[kafkastreamsprocessor.input.topic]`
 
-* `link:#kafka-streams-processor-configuration-keys_kafka.streams.processor-sink-topic[kafkastreamsprocessor.output.topic]` or `link:#kafka-streams-processor-configuration-keys_kafka.streams.processor-sink-topic[kafkastreamsprocessor.output.sinks.<sink>.topic]`
+* `link:#kafka-streams-processor-configuration-keys_kafkastreamsprocessor.output.topic[kafkastreamsprocessor.output.topic]` or `link:#kafka-streams-processor-configuration-keys_kafkastreamsprocessor-output-sinks-sink-topic[kafkastreamsprocessor.output.sinks.<sink>.topic]`
 
 * `link:#kafka-streams-processor-configuration-keys_quarkus.kafka-streams.topics[quarkus.kafka-streams.topics]`
 


### PR DESCRIPTION
One property was not well defined in the configuration table of the documentation.
The link to the field is also updated
