### PR TITLE
fix(spi): remove dependency on kafka-streams

### DIFF
--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -19,11 +19,6 @@
     </dependencies>
   </dependencyManagement>
   <dependencies>
-
-    <dependency>
-      <groupId>io.quarkiverse.kafkastreamsprocessor</groupId>
-      <artifactId>quarkus-kafka-streams-processor-api</artifactId>
-    </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-core</artifactId>
@@ -36,6 +31,10 @@
     <dependency>
       <groupId>org.eclipse.microprofile.config</groupId>
       <artifactId>microprofile-config-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
+      <artifactId>microprofile-fault-tolerance-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/spi/src/main/java/io/quarkiverse/kafkastreamsprocessor/spi/properties/InputConfig.java
+++ b/spi/src/main/java/io/quarkiverse/kafkastreamsprocessor/spi/properties/InputConfig.java
@@ -23,11 +23,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.apache.kafka.streams.processor.api.Record;
-
 /**
- * Configuration relating to the incoming messages for each of which
- * {@link org.apache.kafka.streams.processor.api.Processor#process(Record)} is called.
+ * Configuration related to the messages consumed by the Processor
  */
 public interface InputConfig {
     /**

--- a/spi/src/main/java/io/quarkiverse/kafkastreamsprocessor/spi/properties/KStreamsProcessorConfig.java
+++ b/spi/src/main/java/io/quarkiverse/kafkastreamsprocessor/spi/properties/KStreamsProcessorConfig.java
@@ -20,7 +20,6 @@
 
 package io.quarkiverse.kafkastreamsprocessor.spi.properties;
 
-import io.quarkiverse.kafkastreamsprocessor.api.exception.RetryableException;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 
@@ -53,7 +52,7 @@ public interface KStreamsProcessorConfig {
     String errorStrategy();
 
     /**
-     * All configuration related to the RetryDecorator and reprocessing a record when a {@link RetryableException} has
+     * All configuration related to the RetryDecorator and reprocessing a record when a retryable exception has
      * been caught
      */
     RetryConfig retry();

--- a/spi/src/main/java/io/quarkiverse/kafkastreamsprocessor/spi/properties/OutputConfig.java
+++ b/spi/src/main/java/io/quarkiverse/kafkastreamsprocessor/spi/properties/OutputConfig.java
@@ -22,10 +22,8 @@ package io.quarkiverse.kafkastreamsprocessor.spi.properties;
 import java.util.Map;
 import java.util.Optional;
 
-import io.quarkiverse.kafkastreamsprocessor.api.Processor;
-
 /**
- * Regroups the configuration related to the messages in output of the {@link Processor}.
+ * Configuration related to the messages produced by the Processor
  */
 public interface OutputConfig {
     /**

--- a/spi/src/main/java/io/quarkiverse/kafkastreamsprocessor/spi/properties/RetryConfig.java
+++ b/spi/src/main/java/io/quarkiverse/kafkastreamsprocessor/spi/properties/RetryConfig.java
@@ -91,7 +91,7 @@ public interface RetryConfig {
     /**
      * The list of exception types that should trigger a retry.
      * <p>
-     * Default is the provided {@link io.quarkiverse.kafkastreamsprocessor.api.exception.RetryableException}.
+     * Default is the extension's RetryableException
      * </p>
      *
      * @see Retry#retryOn()


### PR DESCRIPTION
Javadoc links force a dependency on kafka-streams that pollutes the Quarkus augmentation classpath downstream.
Remove the links completely.