### PR TITLE
feat(doc): add valeCLI github action to automatically lint extension …

### DIFF
--- a/.github/styles/Custom/HeadingNestingDepth.yml
+++ b/.github/styles/Custom/HeadingNestingDepth.yml
@@ -1,0 +1,7 @@
+---
+extends: existence
+message: 'The subheading "%s" is nested too deeply. The max heading nesting depth is set to 3.'
+level: error
+scope: raw
+raw:
+  - '(?<=\n)={4,}\s.+'

--- a/.github/styles/Custom/SingleStatementPerLine.yml
+++ b/.github/styles/Custom/SingleStatementPerLine.yml
@@ -1,0 +1,9 @@
+---
+extends: occurrence
+message: Only use one sentence per line.
+level: error
+scope:
+  - paragraph
+  - list
+max: 1
+token: '(?<!Inc|e\.g|etc|i\.e|vs)[.!?](?: |$)'

--- a/.github/styles/config/vocabularies/quarkus-kafka-streams-definitions/accept.txt
+++ b/.github/styles/config/vocabularies/quarkus-kafka-streams-definitions/accept.txt
@@ -1,0 +1,12 @@
+DLQ
+JSON
+kubernetes
+NFRs
+openshift
+opentelemetry
+POJO[?s]
+Protobuf
+Quarkus
+Splunk
+XML
+YAML

--- a/.github/workflows/lint-with-vale.yml
+++ b/.github/workflows/lint-with-vale.yml
@@ -1,0 +1,24 @@
+name: lint-with-vale.yml
+on:
+  pull_request_target:
+    paths:
+      - 'docs/modules/ROOT/pages/**'
+      - '.github/workflows/lint-with-vale.yml'
+
+jobs:
+  vale:
+    name: Linting with Vale
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: errata-ai/vale-action@reviewdog
+        with:
+          files: ./docs/modules/ROOT/pages/
+          filter_mode: added
+          reporter: github-pr-review
+          fail_on_error: false
+        env:
+          # Required, set by GitHub actions automatically:
+          # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          REVIEWDOG_GITHUB_API_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,41 @@
+# Vale configuration file.
+# For more information, see: https://vale.sh/docs/topics/config.
+
+# The relative path to the folder containing linting rules (styles).
+StylesPath = .github/styles
+
+# Minimum alert level
+# -------------------
+# The minimum alert level in the output (suggestion, warning, or error).
+# If integrated into CI, builds fail by default on error-level alerts, unless you run Vale with the --no-exit flag
+MinAlertLevel = warning
+
+# IgnoredScopes specifies inline-level HTML tags to ignore.
+# These tags may occur in an active scope (unlike SkippedScopes, skipped entirely) but their content still will not raise any alerts.
+# Default: ignore `code` and `tt`.
+IgnoredScopes = code, tt, img, url, a, body.id
+
+# SkippedScopes specifies block-level HTML tags to ignore. Ignore any content in these scopes.
+# Default: ignore `script`, `style`, `pre`, and `figure`.
+SkippedScopes = script, style, pre, figure, code, tt, blockquote, listingblock, literalblock
+
+Vocab = quarkus-kafka-streams-definitions
+
+Packages = RedHat, AsciiDoc
+
+[*.adoc]
+BasedOnStyles = Custom, RedHat, AsciiDoc
+
+# Ignore code matching the following patterns:
+# (\x60[^\n\x60]+\x60) - code surrounded by backticks - e.g. `BatchApplication`
+# (:[^\n]+: [^\n]+) - attributes definitions - e.g. `:param: value`
+# ([^\n]+=[^\n]*) - config definitions - e.g. param=value
+# (https?:\/\/[^\n\s]+) - URLs - e.g. https://www.example.com
+# (\b\w+_\w+\b) - snake case words - e.g. batch_application
+# (\b\w+_\w+\b) - kebab case words - e.g. batch-application
+# (\{[^\}]+\}\S+\[) - URLs based on attribute - e.g. {url}/path[link]
+# (^\.\w+\.\w+$) - callouts title - e.g. .pom.xml
+TokenIgnores = (\x60[^\n\x60]+\x60), (:[^\n]+: [^\n]+), ([^\n]+=[^\n]*), (https?:\/\/[^\n\s]+), (\b\w+_\w+\b), (\b\w+-\w+\b), (\{[^\}]+\}\S+\[), (^\.\w+\.\w+$)
+
+# Disable the execution of this style as all our callouts are using include::[] directive
+AsciiDoc.MatchingNumberedCallouts = NO


### PR DESCRIPTION
This pull request introduces a new GitHub Action that uses Vale to lint our project's documentation. Vale is a syntax-aware linter for prose that we can use to enforce style and consistency across our documentation.

The new workflow, defined in `.github/workflows/lint-with-vale.yml`, is triggered on the `pull_request_target` event. This allows the workflow to post review comments on pull requests from forked repositories, as it runs in the context of the base repository and has the necessary write permissions.

The Vale Action is configured to check the files in the `./docs/modules/ROOT/pages/` directory. It uses the `github-pr-review` reporter to post the linting results as a pull request review. If any issues are found, the workflow will fail, ensuring that we maintain a high standard of quality for our documentation.