### PR TITLE
fix(ci): make ValeCLI to produce error/warnings as in-line comments on the PR

### DIFF
--- a/.github/workflows/lint-with-vale.yml
+++ b/.github/workflows/lint-with-vale.yml
@@ -1,6 +1,6 @@
 name: lint-with-vale.yml
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - 'docs/modules/ROOT/pages/**'
       - '.github/workflows/lint-with-vale.yml'
@@ -9,6 +9,8 @@ jobs:
   vale:
     name: Linting with Vale
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - uses: errata-ai/vale-action@reviewdog


### PR DESCRIPTION
This PR is enabling Vale CLI to produce error/warnings as in-line comments on the PR.