### PR TITLE
fix(impl): propagate Opentelemetry baggage and related kafka headers

### DIFF
--- a/impl/src/main/java/io/quarkiverse/kafkastreamsprocessor/impl/protocol/KafkaStreamsProcessorHeaders.java
+++ b/impl/src/main/java/io/quarkiverse/kafkastreamsprocessor/impl/protocol/KafkaStreamsProcessorHeaders.java
@@ -56,6 +56,11 @@ public final class KafkaStreamsProcessorHeaders {
     public static final String W3C_TRACE_ID = "traceparent";
 
     /**
+     * W3C tracing baggage. It is propagated by the opentelemetry if configured to do so.
+     */
+    public static final String W3C_BAGGAGE = "baggage";
+
+    /**
      * The reason of the failure.
      */
     public static final String DLQ_REASON = "dead-letter-reason";


### PR DESCRIPTION
Default usage of Quarkus Opentelemetry is specifying the default [propagators](https://quarkus.io/version/3.8/guides/opentelemetry#quarkus-opentelemetry_quarkus-otel-propagators) as W3C trace and W3C baggage.  The current TracingDecorator code is erasing the W3C baggage header which may be used by functional code.

Change has been done to propagate the Opentelemetry Baggage from the extracted Opentelemetry context (if any). The kafka headers even if erased will be restored from the "child" Opentelemetry context created.

Let me know if I am missing any documentation or tests.
Also, not sure if I should change the .github/project.yaml or maintainer will take care of the release step ?

Best regards
Nicolas Reant  