### PR TITLE
Revert "chore(deps): bump org.hamcrest:hamcrest from 2.2 to 3.0"

### DIFF
--- a/bom/test/pom.xml
+++ b/bom/test/pom.xml
@@ -18,7 +18,7 @@
       <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest</artifactId>
-        <version>3.0</version>
+        <version>2.2</version>
       </dependency>
       <dependency>
         <groupId>com.spotify</groupId>


### PR DESCRIPTION
The purpose of this commit is to revert [this PR](https://github.com/quarkiverse/quarkus-kafka-streams-processor/pull/100)