### PR TITLE
fix(impl): Fix missing DLQ topic error message

### DIFF
--- a/impl/src/main/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/ErrorHandlingStrategy.java
+++ b/impl/src/main/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/ErrorHandlingStrategy.java
@@ -60,7 +60,8 @@ public class ErrorHandlingStrategy {
             if (dlqTopic.isPresent()) {
                 return true;
             } else {
-                throw new IllegalStateException("DLQ strategy enabled but dlq.topic configuration property is missing");
+                throw new IllegalStateException(
+                        "DLQ strategy enabled but kafkastreamsprocessor.dlq.topic configuration property is missing");
             }
         }
         return false;


### PR DESCRIPTION
The message mentions to define a `dlq.topic` configuration entry. Whilst the proper key to define is rather `kafkastreamsprocessor.dlq.topic`.