### PR TITLE
fix(impl): Remove unused constant in ErrorHandlingStrategy

### DIFF
--- a/impl/src/main/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/ErrorHandlingStrategy.java
+++ b/impl/src/main/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/ErrorHandlingStrategy.java
@@ -26,11 +26,6 @@ import java.util.Optional;
  */
 public class ErrorHandlingStrategy {
     /**
-     * Configuration property to check for the Kafka error handling strategy
-     */
-    public static final String CONFIG_PROPERTY = "kafka.error.strategy";
-
-    /**
      * Default strategy: drop the message and continue processing
      */
     public static final String CONTINUE = "continue";


### PR DESCRIPTION
It was the name of the config property used for configuring the error strategy before configuration was centralized in `KStreamsProcessorConfig`. Its name was `kafka.error.strategy`. It is now `kafkastreamsprocessor.error-strategy`.