### PR TITLE
fix(spi): Change unsupported class types in RetryConfig

### DIFF
--- a/spi/src/main/java/io/quarkiverse/kafkastreamsprocessor/spi/properties/RetryConfig.java
+++ b/spi/src/main/java/io/quarkiverse/kafkastreamsprocessor/spi/properties/RetryConfig.java
@@ -97,7 +97,7 @@ public interface RetryConfig {
      * @see Retry#retryOn()
      */
     @WithDefault("io.quarkiverse.kafkastreamsprocessor.api.exception.RetryableException")
-    List<Class<? extends Throwable>> retryOn();
+    List<String> retryOn();
 
     /**
      * The list of exception types that should <i>not</i> trigger a retry.
@@ -108,5 +108,5 @@ public interface RetryConfig {
      * @see Retry#abortOn()
      */
     @WithDefault("")
-    Optional<List<Class<? extends Throwable>>> abortOn();
+    Optional<List<String>> abortOn();
 }


### PR DESCRIPTION
It was discovered whilst trying a fix for another issue and refactoring the repository and moving spi classes to runtime. In runtime the Quarkus annotation processor is applied. And it was failing because of this incorrect configuration interface.

This interface was written using the fields of the `org.eclipse.microprofile.faulttolerance.Retry` annotation. And one can set `Class` object as type of fields of annotation. It is however not supported by `microprofile-config`.

This will have no effect as such, as those configuration entries are directly injected as configuration entries linked to the retryable method of `io.quarkiverse.kafkastreamsprocessor.impl.decorator.processor.RetryDecoratorDelegate`.