### PR TITLE
feat(impl): support custom key type

### DIFF
--- a/api/src/main/java/io/quarkiverse/kafkastreamsprocessor/api/configuration/Configuration.java
+++ b/api/src/main/java/io/quarkiverse/kafkastreamsprocessor/api/configuration/Configuration.java
@@ -36,6 +36,14 @@ import io.quarkiverse.kafkastreamsprocessor.api.configuration.store.StoreConfigu
 public interface Configuration {
 
     /**
+     * Class representing the type of keys handled by the {@link Processor}.
+     * <p>
+     * Default is {@link String}.
+     * </p>
+     */
+    Class<?> getProcessorKeyType();
+
+    /**
      * Class representing the type of values handled by the {@link Processor}. This value
      * is initialized internally by the TopologyProducer. It is read-only because you shouldn't modify it, although you
      * can read it.
@@ -43,6 +51,17 @@ public interface Configuration {
      * It is primarily used to instantiate the default value deserializer using generics.
      */
     Class<?> getProcessorPayloadType();
+
+    /**
+     * Serde for the keys fed to the {@link Processor}. Use the setter if you want to
+     * override it.
+     */
+    void setSourceKeySerde(Serde<?> serde);
+
+    /**
+     * @return The serde for keys fed to the {@link Processor}
+     */
+    Serde<?> getSourceKeySerde();
 
     /**
      * Serde for the value fed to the {@link Processor}. Use the setter if you want to
@@ -54,6 +73,17 @@ public interface Configuration {
      * @return The serde for values fed to the {@link Processor}
      */
     Serde<?> getSourceValueSerde();
+
+    /**
+     * Serializer for values forwarded by the {@link Processor}. Use the setter if you want
+     * to override it.
+     */
+    void setSinkKeySerializer(Serializer<?> serializer);
+
+    /**
+     * @return The serializer for values forwarded by the {@link Processor}
+     */
+    Serializer<?> getSinkKeySerializer();
 
     /**
      * Serializer for values forwarded by the {@link Processor}. Use the setter if you want

--- a/impl/src/main/java/io/quarkiverse/kafkastreamsprocessor/impl/AbstractIntrospectionSerializer.java
+++ b/impl/src/main/java/io/quarkiverse/kafkastreamsprocessor/impl/AbstractIntrospectionSerializer.java
@@ -1,0 +1,51 @@
+/*-
+ * #%L
+ * Quarkus Kafka Streams Processor
+ * %%
+ * Copyright (C) 2024 Amadeus s.a.s.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.quarkiverse.kafkastreamsprocessor.impl;
+
+import org.apache.kafka.common.serialization.Serializer;
+
+import com.google.protobuf.MessageLite;
+
+/**
+ * Bridge serializer based on introspection that allows another serialization policy if the data is not protobuf..
+ */
+public abstract class AbstractIntrospectionSerializer implements Serializer<Object> {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    // Returning null is a valid behaviour here
+    @SuppressWarnings("java:S1168")
+    public byte[] serialize(String topic, Object data) {
+        // null needs to treated specially since the client most likely just wants to send
+        // an individual null value. null in Kafka has a special meaning for deletion in a
+        // topic with the compact retention policy.
+        if (data == null) {
+            return null;
+        }
+        if (data instanceof MessageLite) {
+            return ((MessageLite) data).toByteArray();
+        } else {
+            return serializeNonProtobuf(data);
+        }
+    }
+
+    abstract byte[] serializeNonProtobuf(Object data);
+}

--- a/impl/src/main/java/io/quarkiverse/kafkastreamsprocessor/impl/IntrospectionSerializer.java
+++ b/impl/src/main/java/io/quarkiverse/kafkastreamsprocessor/impl/IntrospectionSerializer.java
@@ -21,16 +21,13 @@ package io.quarkiverse.kafkastreamsprocessor.impl;
 
 import jakarta.inject.Inject;
 
-import org.apache.kafka.common.serialization.Serializer;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.protobuf.MessageLite;
 
 /**
  * Bridge serializer based on introspection that allows a JSON first input message policy.
  */
-public class IntrospectionSerializer implements Serializer<Object> {
+public class IntrospectionSerializer extends AbstractIntrospectionSerializer {
     private final ObjectMapper objectMapper;
 
     /**
@@ -44,27 +41,8 @@ public class IntrospectionSerializer implements Serializer<Object> {
         this.objectMapper = objectMapper;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    // Returning null is a valid behaviour here
-    @SuppressWarnings("java:S1168")
-    public byte[] serialize(String topic, java.lang.Object data) {
-        // null needs to treated specially since the client most likely just wants to send
-        // an individual null value. null in Kafka has a special meaning for deletion in a
-        // topic with the compact retention policy.
-        if (data == null) {
-            return null;
-        }
-        if (data instanceof MessageLite) {
-            return ((MessageLite) data).toByteArray();
-        } else {
-            return serializeAsJson(data);
-        }
-    }
-
-    private byte[] serializeAsJson(Object data) {
+    byte[] serializeNonProtobuf(Object data) {
         try {
             return objectMapper.writeValueAsBytes(data);
         } catch (JsonProcessingException e) {

--- a/impl/src/main/java/io/quarkiverse/kafkastreamsprocessor/impl/StringIntrospectionSerializer.java
+++ b/impl/src/main/java/io/quarkiverse/kafkastreamsprocessor/impl/StringIntrospectionSerializer.java
@@ -1,0 +1,32 @@
+/*-
+ * #%L
+ * Quarkus Kafka Streams Processor
+ * %%
+ * Copyright (C) 2024 Amadeus s.a.s.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.quarkiverse.kafkastreamsprocessor.impl;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Bridge serializer based on introspection that allows a String first input message policy.
+ */
+public class StringIntrospectionSerializer extends AbstractIntrospectionSerializer {
+    @Override
+    byte[] serializeNonProtobuf(Object data) {
+        return data.toString().getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/impl/src/main/java/io/quarkiverse/kafkastreamsprocessor/impl/configuration/TopologyConfigurationImpl.java
+++ b/impl/src/main/java/io/quarkiverse/kafkastreamsprocessor/impl/configuration/TopologyConfigurationImpl.java
@@ -38,7 +38,10 @@ import lombok.Data;
 @Data
 public class TopologyConfigurationImpl implements Configuration {
 
+    private final Class<?> processorKeyType;
     private final Class<?> processorPayloadType;
+    private Serializer<?> sinkKeySerializer;
+    private Serde<?> sourceKeySerde;
     private Serializer<?> sinkValueSerializer;
     private Serde<?> sourceValueSerde;
     private List<StoreConfiguration> storeConfigurations = Collections.emptyList();
@@ -49,7 +52,8 @@ public class TopologyConfigurationImpl implements Configuration {
      * @param processorPayloadType
      *        the input payload type
      */
-    public TopologyConfigurationImpl(Class<?> processorPayloadType) {
+    public TopologyConfigurationImpl(Class<?> processorKeyType, Class<?> processorPayloadType) {
+        this.processorKeyType = processorKeyType;
         this.processorPayloadType = processorPayloadType;
     }
 

--- a/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/CustomKeyTypeSupportedQuarkusTest.java
+++ b/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/CustomKeyTypeSupportedQuarkusTest.java
@@ -1,0 +1,187 @@
+/*-
+ * #%L
+ * Quarkus Kafka Streams Processor
+ * %%
+ * Copyright (C) 2024 Amadeus s.a.s.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.quarkiverse.kafkastreamsprocessor.impl;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.inject.Inject;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.processor.api.ContextualProcessor;
+import org.apache.kafka.streams.processor.api.Record;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+
+import io.opentelemetry.api.trace.Tracer;
+import io.quarkiverse.kafkastreamsprocessor.api.Processor;
+import io.quarkiverse.kafkastreamsprocessor.api.configuration.Configuration;
+import io.quarkiverse.kafkastreamsprocessor.api.configuration.ConfigurationCustomizer;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+@QuarkusTest
+@TestProfile(CustomKeyTypeSupportedQuarkusTest.TestProfile.class)
+public class CustomKeyTypeSupportedQuarkusTest {
+    @ConfigProperty(name = "kafkastreamsprocessor.input.topic")
+    String senderTopic;
+
+    @ConfigProperty(name = "kafkastreamsprocessor.output.topic")
+    String consumerTopic;
+
+    @ConfigProperty(name = "kafka.bootstrap.servers")
+    String bootstrapServers;
+
+    KafkaProducer<KeyType, String> producer;
+
+    KafkaConsumer<KeyType, String> consumer;
+
+    @BeforeEach
+    public void setup() {
+        producer = new KafkaProducer<>(KafkaTestUtils.producerProps(bootstrapServers), new KeySerializer(),
+                new StringSerializer());
+        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(bootstrapServers, "test", "true");
+        consumer = new KafkaConsumer<>(consumerProps, new KeyDeserializer(), new StringDeserializer());
+        consumer.subscribe(List.of(consumerTopic));
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        producer.close();
+        consumer.close();
+    }
+
+    @Test
+    public void customKeyTypeSupported() {
+        ProducerRecord<KeyType, String> sentRecord = new ProducerRecord<>(senderTopic, 0, new KeyType("key"), "value");
+
+        producer.send(sentRecord);
+        producer.flush();
+
+        ConsumerRecord<KeyType, String> singleRecord = KafkaTestUtils.getSingleRecord(consumer, consumerTopic,
+                Duration.ofSeconds(10));
+
+        assertThat(singleRecord.key().getKey(), equalTo("key$"));
+        assertThat(singleRecord.value(), equalTo("valueg"));
+    }
+
+    @Data
+    public static class KeyType {
+        private final String key;
+    }
+
+    public static class KeySerializer implements Serializer<KeyType> {
+        private final StringSerializer serializer = new StringSerializer();
+
+        @Override
+        public void configure(Map<String, ?> configs, boolean isKey) {
+            serializer.configure(configs, isKey);
+        }
+
+        @Override
+        public byte[] serialize(String topic, KeyType keyType) {
+            return serializer.serialize(topic, keyType.getKey());
+        }
+    }
+
+    public static class KeyDeserializer implements Deserializer<KeyType> {
+        private final StringDeserializer deserializer = new StringDeserializer();
+
+        @Override
+        public void configure(Map<String, ?> configs, boolean isKey) {
+            deserializer.configure(configs, isKey);
+        }
+
+        @Override
+        public KeyType deserialize(String topic, byte[] data) {
+            String key = deserializer.deserialize(topic, data);
+            return new KeyType(key);
+        }
+    }
+
+    public static class KeySerde implements Serde<KeyType> {
+        @Override
+        public Serializer<KeyType> serializer() {
+            return new KeySerializer();
+        }
+
+        @Override
+        public Deserializer<KeyType> deserializer() {
+            return new KeyDeserializer();
+        }
+    }
+
+    @Processor
+    @Alternative
+    @Slf4j
+    public static class TestProcessor extends ContextualProcessor<KeyType, String, KeyType, String> {
+        @Inject
+        Tracer tracer;
+
+        @Override
+        public void process(Record<KeyType, String> record) {
+            record = record.withValue(record.value() + "g");
+            record = record.withKey(new KeyType(record.key().getKey() + "$"));
+
+            context().forward(record);
+        }
+    }
+
+    @ApplicationScoped
+    @Alternative
+    public static class MyConfiguration implements ConfigurationCustomizer {
+        @Override
+        public void fillConfiguration(Configuration configuration) {
+            configuration.setSourceKeySerde(new KeySerde());
+            configuration.setSourceValueSerde(Serdes.String());
+            configuration.setSinkKeySerializer(new KeySerializer());
+            configuration.setSinkValueSerializer(new StringSerializer());
+        }
+    }
+
+    public static class TestProfile implements QuarkusTestProfile {
+        @Override
+        public Set<Class<?>> getEnabledAlternatives() {
+            return Set.of(TestProcessor.class, MyConfiguration.class);
+        }
+    }
+}

--- a/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/TopologyProducerTest.java
+++ b/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/TopologyProducerTest.java
@@ -104,6 +104,7 @@ class TopologyProducerTest {
         when(processorSupplier.get()).thenReturn(mock(org.apache.kafka.streams.processor.api.Processor.class),
                 mock(org.apache.kafka.streams.processor.api.Processor.class));
         configuration = mock(TopologyConfigurationImpl.class);
+        when(configuration.getSourceKeySerde()).thenReturn(mock(Serde.class));
         when(configuration.getSourceValueSerde()).thenReturn(mock(Serde.class));
     }
 


### PR DESCRIPTION
Fixes #50.

Default key type is still String.
But it can customized through a `ConfigurationCustomizer` with setters of source/sink key serde and serializer. The key type is extracted dynamically from the generics in the Processor declaration (same as payload detection).