### PR TITLE
fix(test): Migrate to Kafka Native as dev service

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/kafkastreamsprocessor/kafka/streams/test/KafkaStreamsProcessorProcessorTest.java
+++ b/deployment/src/test/java/io/quarkiverse/kafkastreamsprocessor/kafka/streams/test/KafkaStreamsProcessorProcessorTest.java
@@ -50,6 +50,7 @@ public class KafkaStreamsProcessorProcessorTest {
             .overrideConfigKey("kafkastreamsprocessor.input.topics", "ping-events")
             .overrideConfigKey("kafkastreamsprocessor.output.topic", "pong-events")
             .overrideConfigKey("quarkus.kafka-streams.topics", "ping-events,pong-events")
+            .overrideConfigKey("quarkus.kafka.devservices.provider", "kafka-native")
             .addBuildChainCustomizer(buildCustomizer());
 
     private static Consumer<BuildChainBuilder> buildCustomizer() {

--- a/deployment/src/test/java/io/quarkiverse/kafkastreamsprocessor/kafka/streams/test/KafkaStreamsProcessorProcessorWithRetryTest.java
+++ b/deployment/src/test/java/io/quarkiverse/kafkastreamsprocessor/kafka/streams/test/KafkaStreamsProcessorProcessorWithRetryTest.java
@@ -54,6 +54,7 @@ public class KafkaStreamsProcessorProcessorWithRetryTest {
                     "io.quarkiverse.kafkastreamsprocessor.kafka.streams.test.KafkaStreamsProcessorProcessorWithRetryTest$RetryException")
             .overrideConfigKey("kafkastreamsprocessor.retry.abort-on",
                     "io.quarkiverse.kafkastreamsprocessor.kafka.streams.test.KafkaStreamsProcessorProcessorWithRetryTest$AbortException")
+            .overrideConfigKey("quarkus.kafka.devservices.provider", "kafka-native")
             .addBuildChainCustomizer(buildCustomizer());
 
     private static Consumer<BuildChainBuilder> buildCustomizer() {

--- a/impl/src/test/resources/application.properties
+++ b/impl/src/test/resources/application.properties
@@ -16,3 +16,4 @@ quarkus.kafka.devservices.topic-partitions.pang-topic=1
 quarkus.kafka.devservices.topic-partitions.pong-topic=1
 quarkus.kafka.devservices.topic-partitions.dlq-topic=1
 quarkus.otel.propagators=tracecontext,baggage
+quarkus.kafka.devservices.provider=kafka-native

--- a/integration-tests/custom-serde/src/main/resources/application.properties
+++ b/integration-tests/custom-serde/src/main/resources/application.properties
@@ -3,3 +3,4 @@ kafkastreamsprocessor.output.topic=pong-events
 quarkus.kafka-streams.bootstrap-servers=localhost:9092
 quarkus.kafka-streams.topics=ping-events,pong-events
 kafka-streams.producer.linger.ms=0
+quarkus.kafka.devservices.provider=kafka-native

--- a/integration-tests/json-pojo/src/test/resources/application.properties
+++ b/integration-tests/json-pojo/src/test/resources/application.properties
@@ -5,3 +5,4 @@ quarkus.kafka-streams.topics=input,output
 quarkus.kafka.devservices.topic-partitions.input=1
 quarkus.kafka.devservices.topic-partitions.output=1
 quarkus.http.test-port=0
+quarkus.kafka.devservices.provider=kafka-native

--- a/integration-tests/kafka-to-rest/src/main/resources/application.properties
+++ b/integration-tests/kafka-to-rest/src/main/resources/application.properties
@@ -13,4 +13,5 @@ quarkus.kafka.devservices.topic-partitions.pong-events=1
 quarkus.kafka.devservices.topic-partitions.ping-events=1
 %test.quarkus.http.test-port=0
 quarkus.micrometer.export.prometheus.path=/metrics
+quarkus.kafka.devservices.provider=kafka-native
 

--- a/integration-tests/multioutput/src/main/resources/application.properties
+++ b/integration-tests/multioutput/src/main/resources/application.properties
@@ -12,4 +12,5 @@ quarkus.http.test-port=0
 # Runs native test with test profile https://github.com/quarkusio/quarkus/issues/4371
 quarkus.test.native-image-profile=test
 quarkus.micrometer.export.prometheus.path=/metrics
+quarkus.kafka.devservices.provider=kafka-native
 

--- a/integration-tests/simple/src/test/resources/application.properties
+++ b/integration-tests/simple/src/test/resources/application.properties
@@ -1,3 +1,4 @@
 quarkus.http.test-port=0
 quarkus.kafka.devservices.topic-partitions.ping-events=2
 quarkus.kafka.devservices.topic-partitions.pong-events=1
+quarkus.kafka.devservices.provider=kafka-native

--- a/integration-tests/stateful/src/test/resources/application.properties
+++ b/integration-tests/stateful/src/test/resources/application.properties
@@ -8,3 +8,4 @@ quarkus.kafka.devservices.topic-partitions.pong-events=1
 quarkus.kafka.devservices.topic-partitions.pingapp-ping-data-changelog=1
 # Runs native test with test profile https://github.com/quarkusio/quarkus/issues/4371
 quarkus.test.native-image-profile=test
+quarkus.kafka.devservices.provider=kafka-native


### PR DESCRIPTION
Since docker.io has put quotas in place, the download of redpanda is unstabable, breaking randomly the CI and local test executions. Fortunately the Kafka native option is downloading from quay.io, where we do not suffer from quotas (yet).