### PR TITLE
feat(deps): Migration to Quarkus 3.20.0

### DIFF
--- a/integration-tests/multioutput/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/multioutput/PingProcessorIT.java
+++ b/integration-tests/multioutput/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/multioutput/PingProcessorIT.java
@@ -20,7 +20,16 @@
 package io.quarkiverse.kafkastreamsprocessor.sample.multioutput;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
 
 @QuarkusIntegrationTest
+@TestProfile(PingProcessorIT.TestProfile.class)
 public class PingProcessorIT extends PingProcessorQuarkusTest {
+    public static class TestProfile implements QuarkusTestProfile {
+        @Override
+        public String getConfigProfile() {
+            return "test";
+        }
+    }
 }

--- a/integration-tests/simple/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/simple/PingProcessorIT.java
+++ b/integration-tests/simple/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/simple/PingProcessorIT.java
@@ -20,8 +20,16 @@
 package io.quarkiverse.kafkastreamsprocessor.sample.simple;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
 
 @QuarkusIntegrationTest
+@TestProfile(PingProcessorIT.TestProfile.class)
 public class PingProcessorIT extends PingProcessorQuarkusTest {
-
+    public static class TestProfile implements QuarkusTestProfile {
+        @Override
+        public String getConfigProfile() {
+            return "test";
+        }
+    }
 }

--- a/integration-tests/stateful/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/stateful/PingProcessorIT.java
+++ b/integration-tests/stateful/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/stateful/PingProcessorIT.java
@@ -20,7 +20,16 @@
 package io.quarkiverse.kafkastreamsprocessor.sample.stateful;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
 
 @QuarkusIntegrationTest
+@TestProfile(PingProcessorIT.TestProfile.class)
 public class PingProcessorIT extends PingProcessorQuarkusTest {
+    public static class TestProfile implements QuarkusTestProfile {
+        @Override
+        public String getConfigProfile() {
+            return "test";
+        }
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse</groupId>
     <artifactId>quarkiverse-parent</artifactId>
-    <version>18</version>
+    <version>20</version>
   </parent>
   <groupId>io.quarkiverse.kafkastreamsprocessor</groupId>
   <artifactId>quarkus-kafka-streams-processor-parent</artifactId>
@@ -28,12 +28,12 @@
     <tag>HEAD</tag>
   </scm>
   <properties>
-    <compiler-plugin.version>3.13.0</compiler-plugin.version>
+    <compiler-plugin.version>3.14.0</compiler-plugin.version>
     <!-- NB: JDK 17 is required by spring-kafka-test at build time -->
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.15.3</quarkus.version>
+    <quarkus.version>3.20.0</quarkus.version>
 
     <protobuf.version>3.25.5</protobuf.version>
   </properties>

--- a/test-framework/src/main/java/io/quarkiverse/kafkastreamsprocessor/testframework/StateDirCleaningResource.java
+++ b/test-framework/src/main/java/io/quarkiverse/kafkastreamsprocessor/testframework/StateDirCleaningResource.java
@@ -50,7 +50,7 @@ public class StateDirCleaningResource implements QuarkusTestResourceLifecycleMan
     @Override
     public void stop() {
         try {
-            FileUtils.forceDelete(tmpDir);
+            FileUtils.forceDeleteOnExit(tmpDir);
         } catch (Exception e) {
             throw new RuntimeException("error deleting " + tmpDir, e);
         }

--- a/test-framework/src/test/java/io/quarkiverse.kafkastreamsprocessor.testframework/StateDirCleaningResourceTest.java
+++ b/test-framework/src/test/java/io/quarkiverse.kafkastreamsprocessor.testframework/StateDirCleaningResourceTest.java
@@ -23,9 +23,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
-import java.io.File;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -40,8 +38,6 @@ class StateDirCleaningResourceTest {
         assertThat(props, hasEntry(equalTo("kafka-streams.state.dir"), containsString("kstreamstateful")));
 
         resource.stop();
-
-        assertFalse(new File(props.get("kafka-streams.state.dir")).exists());
     }
 
 }


### PR DESCRIPTION
Fixes #161.
Update #162.

Fix integration tests.
Update FileUtils.forceDelete to forceDeleteOnExit to be able to build in Windows

Co-authored-by: edeweerd <emile.deweerd@amadeus.com>