### PR TITLE
fix(docs): Add quarkus processor to spi

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-kafka-streams-processor.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-kafka-streams-processor.adoc
@@ -1,4 +1,3 @@
-:summaryTableId: quarkus-kafka-streams-processor_kafkastreamsprocessor
 [.configuration-legend]
 icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
 [.configuration-reference.searchable, cols="80,.^10,.^10"]
@@ -9,9 +8,17 @@ h|Type
 h|Default
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-input-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-input-topic[`kafkastreamsprocessor.input.topic`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.input.topic+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+Single topic to listen to.
+
+If you need more than one, use `topics()` or `sources()`.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_INPUT_TOPIC+++[]
@@ -24,9 +31,17 @@ endif::add-copy-button-to-env-var[]
 |
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-input-topics]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-input-topics[`kafkastreamsprocessor.input.topics`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.input.topics+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+List of topics to listen to.
+
+If you need only one, use `topic()`
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_INPUT_TOPICS+++[]
@@ -39,9 +54,15 @@ endif::add-copy-button-to-env-var[]
 |
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-input-sources-sources-topics]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-input-sources-sources-topics[`kafkastreamsprocessor.input.sources."sources".topics`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.input.sources."sources".topics+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+To which topics will KafkaStreams connect to for this source.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_INPUT_SOURCES__SOURCES__TOPICS+++[]
@@ -54,9 +75,15 @@ endif::add-copy-button-to-env-var[]
 |required icon:exclamation-circle[title=Configuration property is required]
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-topic[`kafkastreamsprocessor.output.topic`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.output.topic+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+The processor is mono-output, we designate one topic
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_OUTPUT_TOPIC+++[]
@@ -69,9 +96,15 @@ endif::add-copy-button-to-env-var[]
 |
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-sinks-sinks-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-sinks-sinks-topic[`kafkastreamsprocessor.output.sinks."sinks".topic`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.output.sinks."sinks".topic+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+The topic associated to this sink
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_OUTPUT_SINKS__SINKS__TOPIC+++[]
@@ -84,9 +117,15 @@ endif::add-copy-button-to-env-var[]
 |required icon:exclamation-circle[title=Configuration property is required]
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-dlq-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-dlq-topic[`kafkastreamsprocessor.dlq.topic`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.dlq.topic+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+Topic to use as dead-letter-queue
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_DLQ_TOPIC+++[]
@@ -99,9 +138,15 @@ endif::add-copy-button-to-env-var[]
 |
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-global-dlq-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-global-dlq-topic[`kafkastreamsprocessor.global-dlq.topic`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.global-dlq.topic+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+Global Dead letter Queue to produce error messages not managed by the application
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_GLOBAL_DLQ_TOPIC+++[]
@@ -114,9 +159,15 @@ endif::add-copy-button-to-env-var[]
 |
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-global-dlq-max-message-size]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-global-dlq-max-message-size[`kafkastreamsprocessor.global-dlq.max-message-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.global-dlq.max-message-size+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+Global Dead letter Queue maximum message size in bytes. Default is 2147483647 bytes, i.e. about 2GB.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_GLOBAL_DLQ_MAX_MESSAGE_SIZE+++[]
@@ -129,9 +180,21 @@ endif::add-copy-button-to-env-var[]
 |`2147483647`
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-error-strategy]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-error-strategy[`kafkastreamsprocessor.error-strategy`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.error-strategy+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+Kafka error handling strategy.
+
+Possible values are:
+
+ - `continue`: (default) drop the message and continue processing
+ - `dead-letter-queue`: send the message to the DLQ and continue processing
+ - `fail`: (not implemented yet) fail and stop processing more message
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_ERROR_STRATEGY+++[]
@@ -144,9 +207,15 @@ endif::add-copy-button-to-env-var[]
 |`continue`
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-max-retries]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-max-retries[`kafkastreamsprocessor.retry.max-retries`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.retry.max-retries+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+Max number of retries.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_RETRY_MAX_RETRIES+++[]
@@ -159,9 +228,15 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-delay]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-delay[`kafkastreamsprocessor.retry.delay`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.retry.delay+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+The delay between retries.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_RETRY_DELAY+++[]
@@ -174,9 +249,15 @@ endif::add-copy-button-to-env-var[]
 |`0`
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-delay-unit]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-delay-unit[`kafkastreamsprocessor.retry.delay-unit`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.retry.delay-unit+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+The unit for `delay()`. Default milliseconds.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_RETRY_DELAY_UNIT+++[]
@@ -189,9 +270,15 @@ a|`nanos`, `micros`, `millis`, `seconds`, `minutes`, `hours`, `half-days`, `days
 |`millis`
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-max-duration]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-max-duration[`kafkastreamsprocessor.retry.max-duration`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.retry.max-duration+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+The max duration.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_RETRY_MAX_DURATION+++[]
@@ -204,9 +291,17 @@ endif::add-copy-button-to-env-var[]
 |`180000`
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-duration-unit]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-duration-unit[`kafkastreamsprocessor.retry.duration-unit`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.retry.duration-unit+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+The duration unit for `max-duration()`.
+
+Milliseconds by default.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_RETRY_DURATION_UNIT+++[]
@@ -219,9 +314,15 @@ a|`nanos`, `micros`, `millis`, `seconds`, `minutes`, `hours`, `half-days`, `days
 |`millis`
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-jitter]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-jitter[`kafkastreamsprocessor.retry.jitter`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.retry.jitter+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+Jitter value to randomly vary retry delays for.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_RETRY_JITTER+++[]
@@ -234,9 +335,15 @@ endif::add-copy-button-to-env-var[]
 |`200`
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-jitter-delay-unit]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-jitter-delay-unit[`kafkastreamsprocessor.retry.jitter-delay-unit`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.retry.jitter-delay-unit+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+The delay unit for `jitter()`. Default is milliseconds.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_RETRY_JITTER_DELAY_UNIT+++[]
@@ -249,9 +356,17 @@ a|`nanos`, `micros`, `millis`, `seconds`, `minutes`, `hours`, `half-days`, `days
 |`millis`
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-retry-on]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-retry-on[`kafkastreamsprocessor.retry.retry-on`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.retry.retry-on+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+The list of exception types that should trigger a retry.
+
+Default is the extension's RetryableException
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_RETRY_RETRY_ON+++[]
@@ -264,9 +379,17 @@ endif::add-copy-button-to-env-var[]
 |`io.quarkiverse.kafkastreamsprocessor.api.exception.RetryableException`
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-abort-on]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-abort-on[`kafkastreamsprocessor.retry.abort-on`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.retry.abort-on+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+The list of exception types that should _not_ trigger a retry.
+
+Default is empty list
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_RETRY_ABORT_ON+++[]
@@ -280,5 +403,3 @@ endif::add-copy-button-to-env-var[]
 
 |===
 
-
-:!summaryTableId:

--- a/docs/modules/ROOT/pages/includes/quarkus-kafka-streams-processor_kafkastreamsprocessor.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-kafka-streams-processor_kafkastreamsprocessor.adoc
@@ -1,4 +1,3 @@
-:summaryTableId: quarkus-kafka-streams-processor_kafkastreamsprocessor
 [.configuration-legend]
 icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
 [.configuration-reference.searchable, cols="80,.^10,.^10"]
@@ -9,9 +8,17 @@ h|Type
 h|Default
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-input-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-input-topic[`kafkastreamsprocessor.input.topic`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.input.topic+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+Single topic to listen to.
+
+If you need more than one, use `topics()` or `sources()`.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_INPUT_TOPIC+++[]
@@ -24,9 +31,17 @@ endif::add-copy-button-to-env-var[]
 |
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-input-topics]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-input-topics[`kafkastreamsprocessor.input.topics`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.input.topics+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+List of topics to listen to.
+
+If you need only one, use `topic()`
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_INPUT_TOPICS+++[]
@@ -39,9 +54,15 @@ endif::add-copy-button-to-env-var[]
 |
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-input-sources-sources-topics]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-input-sources-sources-topics[`kafkastreamsprocessor.input.sources."sources".topics`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.input.sources."sources".topics+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+To which topics will KafkaStreams connect to for this source.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_INPUT_SOURCES__SOURCES__TOPICS+++[]
@@ -54,9 +75,15 @@ endif::add-copy-button-to-env-var[]
 |required icon:exclamation-circle[title=Configuration property is required]
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-topic[`kafkastreamsprocessor.output.topic`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.output.topic+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+The processor is mono-output, we designate one topic
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_OUTPUT_TOPIC+++[]
@@ -69,9 +96,15 @@ endif::add-copy-button-to-env-var[]
 |
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-sinks-sinks-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-sinks-sinks-topic[`kafkastreamsprocessor.output.sinks."sinks".topic`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.output.sinks."sinks".topic+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+The topic associated to this sink
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_OUTPUT_SINKS__SINKS__TOPIC+++[]
@@ -84,9 +117,15 @@ endif::add-copy-button-to-env-var[]
 |required icon:exclamation-circle[title=Configuration property is required]
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-dlq-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-dlq-topic[`kafkastreamsprocessor.dlq.topic`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.dlq.topic+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+Topic to use as dead-letter-queue
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_DLQ_TOPIC+++[]
@@ -99,9 +138,15 @@ endif::add-copy-button-to-env-var[]
 |
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-global-dlq-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-global-dlq-topic[`kafkastreamsprocessor.global-dlq.topic`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.global-dlq.topic+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+Global Dead letter Queue to produce error messages not managed by the application
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_GLOBAL_DLQ_TOPIC+++[]
@@ -114,9 +159,15 @@ endif::add-copy-button-to-env-var[]
 |
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-global-dlq-max-message-size]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-global-dlq-max-message-size[`kafkastreamsprocessor.global-dlq.max-message-size`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.global-dlq.max-message-size+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+Global Dead letter Queue maximum message size in bytes. Default is 2147483647 bytes, i.e. about 2GB.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_GLOBAL_DLQ_MAX_MESSAGE_SIZE+++[]
@@ -129,9 +180,21 @@ endif::add-copy-button-to-env-var[]
 |`2147483647`
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-error-strategy]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-error-strategy[`kafkastreamsprocessor.error-strategy`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.error-strategy+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+Kafka error handling strategy.
+
+Possible values are:
+
+ - `continue`: (default) drop the message and continue processing
+ - `dead-letter-queue`: send the message to the DLQ and continue processing
+ - `fail`: (not implemented yet) fail and stop processing more message
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_ERROR_STRATEGY+++[]
@@ -144,9 +207,15 @@ endif::add-copy-button-to-env-var[]
 |`continue`
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-max-retries]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-max-retries[`kafkastreamsprocessor.retry.max-retries`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.retry.max-retries+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+Max number of retries.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_RETRY_MAX_RETRIES+++[]
@@ -159,9 +228,15 @@ endif::add-copy-button-to-env-var[]
 |`-1`
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-delay]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-delay[`kafkastreamsprocessor.retry.delay`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.retry.delay+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+The delay between retries.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_RETRY_DELAY+++[]
@@ -174,9 +249,15 @@ endif::add-copy-button-to-env-var[]
 |`0`
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-delay-unit]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-delay-unit[`kafkastreamsprocessor.retry.delay-unit`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.retry.delay-unit+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+The unit for `delay()`. Default milliseconds.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_RETRY_DELAY_UNIT+++[]
@@ -189,9 +270,15 @@ a|`nanos`, `micros`, `millis`, `seconds`, `minutes`, `hours`, `half-days`, `days
 |`millis`
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-max-duration]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-max-duration[`kafkastreamsprocessor.retry.max-duration`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.retry.max-duration+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+The max duration.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_RETRY_MAX_DURATION+++[]
@@ -204,9 +291,17 @@ endif::add-copy-button-to-env-var[]
 |`180000`
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-duration-unit]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-duration-unit[`kafkastreamsprocessor.retry.duration-unit`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.retry.duration-unit+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+The duration unit for `max-duration()`.
+
+Milliseconds by default.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_RETRY_DURATION_UNIT+++[]
@@ -219,9 +314,15 @@ a|`nanos`, `micros`, `millis`, `seconds`, `minutes`, `hours`, `half-days`, `days
 |`millis`
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-jitter]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-jitter[`kafkastreamsprocessor.retry.jitter`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.retry.jitter+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+Jitter value to randomly vary retry delays for.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_RETRY_JITTER+++[]
@@ -234,9 +335,15 @@ endif::add-copy-button-to-env-var[]
 |`200`
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-jitter-delay-unit]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-jitter-delay-unit[`kafkastreamsprocessor.retry.jitter-delay-unit`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.retry.jitter-delay-unit+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+The delay unit for `jitter()`. Default is milliseconds.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_RETRY_JITTER_DELAY_UNIT+++[]
@@ -249,9 +356,17 @@ a|`nanos`, `micros`, `millis`, `seconds`, `minutes`, `hours`, `half-days`, `days
 |`millis`
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-retry-on]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-retry-on[`kafkastreamsprocessor.retry.retry-on`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.retry.retry-on+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+The list of exception types that should trigger a retry.
+
+Default is the extension's RetryableException
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_RETRY_RETRY_ON+++[]
@@ -264,9 +379,17 @@ endif::add-copy-button-to-env-var[]
 |`io.quarkiverse.kafkastreamsprocessor.api.exception.RetryableException`
 
 a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-abort-on]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-abort-on[`kafkastreamsprocessor.retry.abort-on`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++kafkastreamsprocessor.retry.abort-on+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
+The list of exception types that should _not_ trigger a retry.
+
+Default is empty list
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++KAFKASTREAMSPROCESSOR_RETRY_ABORT_ON+++[]
@@ -280,5 +403,3 @@ endif::add-copy-button-to-env-var[]
 
 |===
 
-
-:!summaryTableId:

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -69,4 +69,20 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>io.quarkus</groupId>
+              <artifactId>quarkus-extension-processor</artifactId>
+              <version>${quarkus.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/spi/src/main/java/io/quarkiverse/kafkastreamsprocessor/spi/KStreamsProcessorConfigGenerator.java
+++ b/spi/src/main/java/io/quarkiverse/kafkastreamsprocessor/spi/KStreamsProcessorConfigGenerator.java
@@ -17,9 +17,6 @@ import io.quarkiverse.kafkastreamsprocessor.spi.properties.OutputConfig;
 import io.quarkiverse.kafkastreamsprocessor.spi.properties.RetryConfig;
 import io.quarkiverse.kafkastreamsprocessor.spi.properties.SinkConfig;
 import io.quarkiverse.kafkastreamsprocessor.spi.properties.SourceConfig;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.experimental.Accessors;
 
 class KStreamsProcessorConfigGenerator {
 
@@ -28,89 +25,182 @@ class KStreamsProcessorConfigGenerator {
     private static final Pattern P_SINK = Pattern.compile("kafkastreamsprocessor\\.output\\.sinks\\.(.*)\\.topic");
 
     static KStreamsProcessorConfig buildConfig(Config config) {
-        InputConfigImpl input = new InputConfigImpl(config.getOptionalValue("kafkastreamsprocessor.input.topic", String.class),
-                config.getOptionalValues("kafkastreamsprocessor.input.topics", String.class));
+        InputConfigImpl input = new InputConfigImpl();
+        input.setTopic(config.getOptionalValue("kafkastreamsprocessor.input.topic", String.class));
+        input.setTopics(config.getOptionalValues("kafkastreamsprocessor.input.topics", String.class));
         fillSources(config, input);
-        OutputConfigImpl output = new OutputConfigImpl(
-                config.getOptionalValue("kafkastreamsprocessor.output.topic", String.class));
+        OutputConfigImpl output = new OutputConfigImpl();
+        output.setTopic(config.getOptionalValue("kafkastreamsprocessor.output.topic", String.class));
         fillSinks(config, output);
-        return new KStreamsProcessorConfigImpl(input, output);
+        KStreamsProcessorConfigImpl kStreamsProcessorConfig = new KStreamsProcessorConfigImpl();
+        kStreamsProcessorConfig.setInput(input);
+        kStreamsProcessorConfig.setOutput(output);
+        return kStreamsProcessorConfig;
     }
 
     private static void fillSources(Config config, InputConfigImpl input) {
+        Map<String, SourceConfig> sources = new HashMap<>();
         for (String property : config.getPropertyNames()) {
             Matcher matcher = P_SOURCE.matcher(property);
             if (matcher.matches()) {
                 String sourceName = matcher.group(1);
                 String topics = config.getValue(property, String.class);
-                SourceConfig sourceConfig = new SourceConfigImpl(List.of(topics.split(",")));
+                SourceConfigImpl sourceConfig = new SourceConfigImpl();
+                sourceConfig.setTopics(List.of(topics.split(",")));
                 if (sourceName.contains(".")) {
                     throw new IllegalStateException("Parsed source name has a dot: " + sourceName);
                 }
-                input.sources().put(sourceName, sourceConfig);
+                sources.put(sourceName, sourceConfig);
             }
         }
+        input.setSources(sources);
     }
 
     private static void fillSinks(Config config, OutputConfigImpl output) {
+        Map<String, SinkConfig> sinks = new HashMap<>();
         for (String property : config.getPropertyNames()) {
             Matcher matcher = P_SINK.matcher(property);
             if (matcher.matches()) {
                 String sinkName = matcher.group(1);
                 String topic = config.getValue(property, String.class);
-                SinkConfig sinkConfig = new SinkConfigImpl(topic);
+                SinkConfigImpl sinkConfig = new SinkConfigImpl();
+                sinkConfig.setTopic(topic);
                 if (sinkName.contains(".")) {
                     throw new IllegalStateException("Parsed sink name has a dot: " + sinkName);
                 }
-                output.sinks().put(sinkName, sinkConfig);
+                sinks.put(sinkName, sinkConfig);
             }
+        }
+        output.setSinks(sinks);
+    }
+
+    private static class KStreamsProcessorConfigImpl implements KStreamsProcessorConfig {
+        private InputConfig input;
+        private OutputConfig output;
+
+        @Override
+        public InputConfig input() {
+            return input;
+        }
+
+        public void setInput(InputConfig input) {
+            this.input = input;
+        }
+
+        @Override
+        public OutputConfig output() {
+            return output;
+        }
+
+        public void setOutput(OutputConfig output) {
+            this.output = output;
+        }
+
+        @Override
+        public DlqConfig dlq() {
+            return null;
+        }
+
+        @Override
+        public GlobalDlqConfig globalDlq() {
+            return null;
+        }
+
+        @Override
+        public String errorStrategy() {
+            return null;
+        }
+
+        @Override
+        public RetryConfig retry() {
+            return null;
         }
     }
 
-    @RequiredArgsConstructor
-    @Getter
-    @Accessors(fluent = true)
-    private static class KStreamsProcessorConfigImpl implements KStreamsProcessorConfig {
-        private final InputConfig input;
-        private final OutputConfig output;
-        private final DlqConfig dlq = null;
-        private final GlobalDlqConfig globalDlq = null;
-        private final String errorStrategy = "";
-        private final RetryConfig retry = null;
-    }
-
-    @RequiredArgsConstructor
-    @Getter
-    @Accessors(fluent = true)
     private static class InputConfigImpl implements InputConfig {
-        private final Optional<String> topic;
+        private Optional<String> topic;
 
-        private final Optional<List<String>> topics;
+        private Optional<List<String>> topics;
 
-        private final Map<String, SourceConfig> sources = new HashMap<>();
+        private Map<String, SourceConfig> sources;
+
+        @Override
+        public Optional<String> topic() {
+            return topic;
+        }
+
+        public void setTopic(Optional<String> topic) {
+            this.topic = topic;
+        }
+
+        @Override
+        public Optional<List<String>> topics() {
+            return topics;
+        }
+
+        public void setTopics(Optional<List<String>> topics) {
+            this.topics = topics;
+        }
+
+        @Override
+        public Map<String, SourceConfig> sources() {
+            return sources;
+        }
+
+        public void setSources(
+                Map<String, SourceConfig> sources) {
+            this.sources = sources;
+        }
     }
 
-    @RequiredArgsConstructor
-    @Getter
-    @Accessors(fluent = true)
     private static class SourceConfigImpl implements SourceConfig {
-        private final List<String> topics;
+        private List<String> topics;
+
+        @Override
+        public List<String> topics() {
+            return topics;
+        }
+
+        public void setTopics(List<String> topics) {
+            this.topics = topics;
+        }
     }
 
-    @RequiredArgsConstructor
-    @Getter
-    @Accessors(fluent = true)
     private static class OutputConfigImpl implements OutputConfig {
-        private final Optional<String> topic;
+        private Optional<String> topic;
 
-        private final Map<String, SinkConfig> sinks = new HashMap<>();
+        private Map<String, SinkConfig> sinks;
+
+        @Override
+        public Optional<String> topic() {
+            return topic;
+        }
+
+        public void setTopic(Optional<String> topic) {
+            this.topic = topic;
+        }
+
+        @Override
+        public Map<String, SinkConfig> sinks() {
+            return sinks;
+        }
+
+        public void setSinks(Map<String, SinkConfig> sinks) {
+            this.sinks = sinks;
+        }
     }
 
-    @RequiredArgsConstructor
-    @Getter
-    @Accessors(fluent = true)
     private static class SinkConfigImpl implements SinkConfig {
-        private final String topic;
+        private String topic;
+
+        @Override
+        public String topic() {
+            return topic;
+        }
+
+        public void setTopic(String topic) {
+            this.topic = topic;
+        }
     }
 
 }

--- a/spi/src/main/java/io/quarkiverse/kafkastreamsprocessor/spi/properties/GlobalDlqConfig.java
+++ b/spi/src/main/java/io/quarkiverse/kafkastreamsprocessor/spi/properties/GlobalDlqConfig.java
@@ -33,7 +33,8 @@ public interface GlobalDlqConfig {
     Optional<String> topic();
 
     /**
-     * Global Dead letter Queue maximum message size
+     * Global Dead letter Queue maximum message size in bytes.
+     * Default is 2147483647 bytes, i.e. about 2GB.
      */
     @WithDefault("2147483647")
     int maxMessageSize();

--- a/spi/src/main/java/io/quarkiverse/kafkastreamsprocessor/spi/properties/KStreamsProcessorConfig.java
+++ b/spi/src/main/java/io/quarkiverse/kafkastreamsprocessor/spi/properties/KStreamsProcessorConfig.java
@@ -23,6 +23,9 @@ package io.quarkiverse.kafkastreamsprocessor.spi.properties;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 
+/**
+ * Root of the configuration of the <code>quarkus-kafka-streams-processor</code> Quarkiverse extension.
+ */
 @ConfigMapping(prefix = "kafkastreamsprocessor")
 public interface KStreamsProcessorConfig {
     /**
@@ -46,7 +49,15 @@ public interface KStreamsProcessorConfig {
     GlobalDlqConfig globalDlq();
 
     /**
-     * Kafka error handling strategy
+     * Kafka error handling strategy.
+     * <p>
+     * Possible values are:
+     * </p>
+     * <ul>
+     * <li><code>continue</code>: (default) drop the message and continue processing</li>
+     * <li><code>dead-letter-queue</code>: send the message to the DLQ and continue processing</li>
+     * <li><code>fail</code>: (not implemented yet) fail and stop processing more message</li>
+     * </ul>
      */
     @WithDefault("continue")
     String errorStrategy();

--- a/spi/src/main/java/io/quarkiverse/kafkastreamsprocessor/spi/properties/RetryConfig.java
+++ b/spi/src/main/java/io/quarkiverse/kafkastreamsprocessor/spi/properties/RetryConfig.java
@@ -27,6 +27,9 @@ import org.eclipse.microprofile.faulttolerance.Retry;
 
 import io.smallrye.config.WithDefault;
 
+/**
+ * Retry fault-tolerance capability
+ */
 public interface RetryConfig {
 
     /**


### PR DESCRIPTION
Currently main is not building because the configuration documentation generation is failing, complaining of missing javadoc. Turns out the pb is we do not run the quarkus-extension-processor on the spi module, which contains the actual configuration interfaces. Fortunately adding the quarkus-extension-processor on the `spi` module seems to solve the issue.

However it had a side effect on `KStreamsProcessorConfigGenerator`: the private classes implementing the config interfaces need now a default constructor and some incompatibility with lombok was found. Consequently removed lombok annotations, `final` keywords on field declaration, and write getter/setters manually.