### PR TITLE
fix: close existing DLQ producers before reconfiguration to prevent resource leak.

### DIFF
--- a/impl/src/main/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/DlqProducerService.java
+++ b/impl/src/main/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/DlqProducerService.java
@@ -125,6 +125,16 @@ public class DlqProducerService implements Configurable {
         sendToDlq = ErrorHandlingStrategy.shouldSendToDlq(kStreamsProcessorConfig.errorStrategy(),
                 kStreamsProcessorConfig.dlq().topic());
         if (sendToDlq) {
+            // Close existing producer before creating a new one to prevent resource leak
+            if (dlqProducer != null) {
+                try {
+                    dlqProducer.close();
+                    log.debug("Closed existing DLQ producer before reconfiguration");
+                } catch (Exception e) {
+                    log.warn("Failed to close existing DLQ producer during reconfiguration", e);
+                }
+            }
+
             Map<String, Object> dlqConfigMap = new HashMap<>(configs);
             dlqConfigMap.put(KafkaClientSupplierDecorator.DLQ_PRODUCER, true);
             dlqProducer = new LogCallbackExceptionProducerDecorator(clientSupplier.getProducer(dlqConfigMap));

--- a/impl/src/main/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/GlobalDLQProductionExceptionHandlerDelegate.java
+++ b/impl/src/main/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/GlobalDLQProductionExceptionHandlerDelegate.java
@@ -146,6 +146,16 @@ class GlobalDLQProductionExceptionHandlerDelegate implements ProductionException
         Map<String, Object> producerConfig = (Map<String, Object>) config;
 
         if (kStreamsProcessorConfig.globalDlq().topic().isPresent()) {
+            // Close existing producer before creating a new one to prevent resource leak
+            if (kafkaProducer != null) {
+                try {
+                    kafkaProducer.close();
+                    log.debug("Closed existing global DLQ producer before reconfiguration");
+                } catch (Exception e) {
+                    log.warn("Failed to close existing global DLQ producer during reconfiguration", e);
+                }
+            }
+
             Map<String, Object> dqlProducerConfig = new HashMap<>(producerConfig);
             dqlProducerConfig.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG,
                     kStreamsProcessorConfig.globalDlq().maxMessageSize());

--- a/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/DlqProducerServiceTest.java
+++ b/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/DlqProducerServiceTest.java
@@ -193,4 +193,30 @@ class DlqProducerServiceTest {
 
         verify(dlqMetadataHandler).withMetadata(originalHeaders, SOURCE_TOPIC, PARTITION, exception);
     }
+
+    @Test
+    void shouldCloseOldProducerWhenConfigureCalledMultipleTimes() {
+        when(dlqConfig.topic()).thenReturn(Optional.of(DLQ_TOPIC));
+        when(kStreamsProcessorConfig.errorStrategy()).thenReturn(ErrorHandlingStrategy.DEAD_LETTER_QUEUE);
+
+        @SuppressWarnings("unchecked")
+        Producer<byte[], byte[]> firstProducer = org.mockito.Mockito.mock(Producer.class);
+        @SuppressWarnings("unchecked")
+        Producer<byte[], byte[]> secondProducer = org.mockito.Mockito.mock(Producer.class);
+
+        when(kafkaClientSupplier.getProducer(any()))
+                .thenReturn(firstProducer)
+                .thenReturn(secondProducer);
+
+        // First configure call - creates first producer
+        service.configure(Collections.emptyMap());
+
+        // Second configure call - should close first producer before creating second
+        service.configure(Collections.emptyMap());
+
+        // Verify first producer was closed
+        verify(firstProducer).close();
+        // Verify second producer was created
+        verify(kafkaClientSupplier, org.mockito.Mockito.times(2)).getProducer(any());
+    }
 }


### PR DESCRIPTION
Fixes #259
 
## Problem
KafkaProducer resource leak occurs in DLQ handlers when `configure()` is called multiple times during consumer rebalances.
 
In Kafka 4.0+, `DeserializationExceptionHandler` instances are created per-task (not per-StreamThread). With N assigned partitions, this results in N-1 leaked producers per rebalance, each holding ~2-5MB of native memory.
 
## Solution
Close existing producer (if any) before creating a new one in:
- `DlqProducerService.configure()`
- `GlobalDLQProductionExceptionHandlerDelegate.configure()`
 
## Testing
- Existing tests pass