### PR TITLE
fix: prevent KafkaProducer resource leak on Kafka Streams rebalance (Backport from main)

### DIFF
--- a/impl/src/main/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/DlqProducerService.java
+++ b/impl/src/main/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/DlqProducerService.java
@@ -125,9 +125,11 @@ public class DlqProducerService implements Configurable {
         sendToDlq = ErrorHandlingStrategy.shouldSendToDlq(kStreamsProcessorConfig.errorStrategy(),
                 kStreamsProcessorConfig.dlq().topic());
         if (sendToDlq) {
-            Map<String, Object> dlqConfigMap = new HashMap<>(configs);
-            dlqConfigMap.put(KafkaClientSupplierDecorator.DLQ_PRODUCER, true);
-            dlqProducer = new LogCallbackExceptionProducerDecorator(clientSupplier.getProducer(dlqConfigMap));
+            if (dlqProducer == null) {
+                Map<String, Object> dlqConfigMap = new HashMap<>(configs);
+                dlqConfigMap.put(KafkaClientSupplierDecorator.DLQ_PRODUCER, true);
+                dlqProducer = new LogCallbackExceptionProducerDecorator(clientSupplier.getProducer(dlqConfigMap));
+            }
         }
     }
 

--- a/impl/src/main/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/GlobalDLQProductionExceptionHandlerDelegate.java
+++ b/impl/src/main/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/GlobalDLQProductionExceptionHandlerDelegate.java
@@ -146,11 +146,13 @@ class GlobalDLQProductionExceptionHandlerDelegate implements ProductionException
         Map<String, Object> producerConfig = (Map<String, Object>) config;
 
         if (kStreamsProcessorConfig.globalDlq().topic().isPresent()) {
-            Map<String, Object> dqlProducerConfig = new HashMap<>(producerConfig);
-            dqlProducerConfig.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG,
-                    kStreamsProcessorConfig.globalDlq().maxMessageSize());
-            dqlProducerConfig.put(KafkaClientSupplierDecorator.DLQ_PRODUCER, true);
-            kafkaProducer = new LogCallbackExceptionProducerDecorator(clientSupplier.getProducer(dqlProducerConfig));
+            if (kafkaProducer == null) {
+                Map<String, Object> dqlProducerConfig = new HashMap<>(producerConfig);
+                dqlProducerConfig.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG,
+                        kStreamsProcessorConfig.globalDlq().maxMessageSize());
+                dqlProducerConfig.put(KafkaClientSupplierDecorator.DLQ_PRODUCER, true);
+                kafkaProducer = new LogCallbackExceptionProducerDecorator(clientSupplier.getProducer(dqlProducerConfig));
+            }
         }
     }
 

--- a/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/DlqProducerServiceTest.java
+++ b/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/DlqProducerServiceTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -192,5 +193,17 @@ class DlqProducerServiceTest {
         service.sendToDlq(consumerRecord, exception, new TaskId(0, PARTITION), false);
 
         verify(dlqMetadataHandler).withMetadata(originalHeaders, SOURCE_TOPIC, PARTITION, exception);
+    }
+
+    @Test
+    void shouldNotRecreateProducerOnSubsequentConfigureCalls() {
+        when(dlqConfig.topic()).thenReturn(Optional.of(DLQ_TOPIC));
+        when(kStreamsProcessorConfig.errorStrategy()).thenReturn(ErrorHandlingStrategy.DEAD_LETTER_QUEUE);
+        when(kafkaClientSupplier.getProducer(any())).thenReturn(dlqProducer);
+
+        service.configure(Collections.emptyMap());
+        service.configure(Collections.emptyMap());
+
+        verify(kafkaClientSupplier, times(1)).getProducer(any());
     }
 }

--- a/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/GlobalDLQProductionExceptionHandlerDelegateTest.java
+++ b/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/GlobalDLQProductionExceptionHandlerDelegateTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -123,5 +124,13 @@ class GlobalDLQProductionExceptionHandlerDelegateTest {
                 "key".getBytes(), "value".getBytes());
         globalDLQExceptionHandlerDelegate.handle(errorRecord, new TestException());
         assertThat(metrics.globalDlqSentCounter().count(), closeTo(0, 0));
+    }
+
+    @Test
+    public void shouldNotRecreateProducerOnSubsequentConfigureCalls() {
+        // configure() was already called once in @BeforeEach
+        globalDLQExceptionHandlerDelegate.configure(Collections.emptyMap());
+
+        verify(kafkaClientSupplier, times(1)).getProducer(any());
     }
 }


### PR DESCRIPTION
The configure() method of DlqProducerService and GlobalDLQProductionExceptionHandlerDelegate implements the Kafka Configurable interface, which is called by the Kafka Streams runtime each time a task is (re)assigned to the stream thread — i.e., on every rebalance.

The original implementation unconditionally overwrote the dlqProducer field with a new KafkaProducer instance on every configure() call, without closing the previous one. This caused a resource leak: on every rebalance (e.g., partition count change, new replica joining), the old producer's internal threads, network connections, and buffers were silently abandoned and never cleaned up.

The fix guards producer creation with a null check: the producer is created only on the first configure() call and reused on subsequent ones. This is safe because:
- The Kafka configuration (including SASL/OAUTHBEARER credentials) is static for the lifetime of the pod
- KafkaProducer is thread-safe and designed to be long-lived.

The issue and its fix is inspired from a PR too early closed: https://github.com/quarkiverse/quarkus-kafka-streams-processor/pull/260