### PR TITLE
fix(impl): Preserve trace headers on DLQ sends

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/gastaldi"><img src="https://avatars.githubusercontent.com/u/54133?v=4" width="100px;" alt=""/><br /><sub><b>gastaldi</b></sub></a><br /><a href="https://github.com/quarkiverse/quarkus-kafka-streams-processor/commits?author=gastaldi" title="Code">💻</a> </td>
     <td align="center"><a href="https://github.com/Annlazar"><img src="https://avatars.githubusercontent.com/u/26568868?v=4" width="100px;" alt=""/><br /><sub><b>Annlazar</b></sub></a><br /><a href="https://github.com/quarkiverse/quarkus-kafka-streams-processor/commits?author=Annlazar" title="Code">💻</a> </td>
     <td align="center"><a href="https://github.com/nreant1A"><img src="https://avatars.githubusercontent.com/u/173859415?v=4" width="100px;" alt=""/><br /><sub><b>nreant1A</b></sub></a><br /><a href="https://github.com/quarkiverse/quarkus-kafka-streams-processor/commits?author=nreant1A" title="Code">💻</a> </td>
+    <td align="center"><a href="https://github.com/amelliani1A"><img src="https://avatars.githubusercontent.com/u/272270451?v=4" width="100px;" alt=""/><br /><sub><b>amelliani1A</b></sub></a><br /><a href="https://github.com/quarkiverse/quarkus-kafka-streams-processor/commits?author=amelliani1A" title="Code">💻</a> </td>
   </tr>
 </table>
 

--- a/docs/modules/ROOT/pages/includes/quarkus-kafka-streams-processor.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-kafka-streams-processor.adoc
@@ -7,7 +7,7 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-input-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-input-topic[`kafkastreamsprocessor.input.topic`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-input-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-input-topic[`+++kafkastreamsprocessor.input.topic+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.input.topic+++[]
 endif::add-copy-button-to-config-props[]
@@ -30,7 +30,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-input-topics]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-input-topics[`kafkastreamsprocessor.input.topics`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-input-topics]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-input-topics[`+++kafkastreamsprocessor.input.topics+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.input.topics+++[]
 endif::add-copy-button-to-config-props[]
@@ -53,7 +53,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-input-sources-sources-topics]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-input-sources-sources-topics[`kafkastreamsprocessor.input.sources."sources".topics`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-input-sources-sources-topics]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-input-sources-sources-topics[`+++kafkastreamsprocessor.input.sources."sources".topics+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.input.sources."sources".topics+++[]
 endif::add-copy-button-to-config-props[]
@@ -74,7 +74,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |required icon:exclamation-circle[title=Configuration property is required]
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-input-is-cloud-event]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-input-is-cloud-event[`kafkastreamsprocessor.input.is-cloud-event`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-input-is-cloud-event]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-input-is-cloud-event[`+++kafkastreamsprocessor.input.is-cloud-event+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.input.is-cloud-event+++[]
 endif::add-copy-button-to-config-props[]
@@ -95,7 +95,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-input-cloud-event-deserializer-config-cloud-event-deserializer-config]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-input-cloud-event-deserializer-config-cloud-event-deserializer-config[`kafkastreamsprocessor.input.cloud-event-deserializer-config."cloud-event-deserializer-config"`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-input-cloud-event-deserializer-config-cloud-event-deserializer-config]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-input-cloud-event-deserializer-config-cloud-event-deserializer-config[`+++kafkastreamsprocessor.input.cloud-event-deserializer-config."cloud-event-deserializer-config"+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.input.cloud-event-deserializer-config."cloud-event-deserializer-config"+++[]
 endif::add-copy-button-to-config-props[]
@@ -120,7 +120,7 @@ endif::add-copy-button-to-env-var[]
 |Map<String,String>
 |
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-topic[`kafkastreamsprocessor.output.topic`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-topic[`+++kafkastreamsprocessor.output.topic+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.output.topic+++[]
 endif::add-copy-button-to-config-props[]
@@ -141,7 +141,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-sinks-sinks-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-sinks-sinks-topic[`kafkastreamsprocessor.output.sinks."sinks".topic`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-sinks-sinks-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-sinks-sinks-topic[`+++kafkastreamsprocessor.output.sinks."sinks".topic+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.output.sinks."sinks".topic+++[]
 endif::add-copy-button-to-config-props[]
@@ -162,7 +162,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |required icon:exclamation-circle[title=Configuration property is required]
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-is-cloud-event]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-is-cloud-event[`kafkastreamsprocessor.output.is-cloud-event`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-is-cloud-event]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-is-cloud-event[`+++kafkastreamsprocessor.output.is-cloud-event+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.output.is-cloud-event+++[]
 endif::add-copy-button-to-config-props[]
@@ -183,7 +183,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-event-serializer-config-cloud-event-serializer-config]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-event-serializer-config-cloud-event-serializer-config[`kafkastreamsprocessor.output.cloud-event-serializer-config."cloud-event-serializer-config"`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-event-serializer-config-cloud-event-serializer-config]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-event-serializer-config-cloud-event-serializer-config[`+++kafkastreamsprocessor.output.cloud-event-serializer-config."cloud-event-serializer-config"+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.output.cloud-event-serializer-config."cloud-event-serializer-config"+++[]
 endif::add-copy-button-to-config-props[]
@@ -206,7 +206,7 @@ endif::add-copy-button-to-env-var[]
 |Map<String,String>
 |
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-type]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-type[`kafkastreamsprocessor.output.cloud-events-type`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-type]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-type[`+++kafkastreamsprocessor.output.cloud-events-type+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.output.cloud-events-type+++[]
 endif::add-copy-button-to-config-props[]
@@ -229,7 +229,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-source]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-source[`kafkastreamsprocessor.output.cloud-events-source`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-source]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-source[`+++kafkastreamsprocessor.output.cloud-events-source+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.output.cloud-events-source+++[]
 endif::add-copy-button-to-config-props[]
@@ -252,7 +252,7 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/net/URI.html[URI]
 |
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-spec-version]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-spec-version[`kafkastreamsprocessor.output.cloud-events-spec-version`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-spec-version]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-spec-version[`+++kafkastreamsprocessor.output.cloud-events-spec-version+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.output.cloud-events-spec-version+++[]
 endif::add-copy-button-to-config-props[]
@@ -273,7 +273,7 @@ endif::add-copy-button-to-env-var[]
 a|`v03`, `v1`
 |`+++v1+++`
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-insert-timestamp]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-insert-timestamp[`kafkastreamsprocessor.output.cloud-events-insert-timestamp`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-insert-timestamp]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-insert-timestamp[`+++kafkastreamsprocessor.output.cloud-events-insert-timestamp+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.output.cloud-events-insert-timestamp+++[]
 endif::add-copy-button-to-config-props[]
@@ -294,7 +294,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-global-stores-global-stores-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-global-stores-global-stores-topic[`kafkastreamsprocessor.global-stores."global-stores".topic`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-global-stores-global-stores-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-global-stores-global-stores-topic[`+++kafkastreamsprocessor.global-stores."global-stores".topic+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.global-stores."global-stores".topic+++[]
 endif::add-copy-button-to-config-props[]
@@ -315,7 +315,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |required icon:exclamation-circle[title=Configuration property is required]
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-dlq-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-dlq-topic[`kafkastreamsprocessor.dlq.topic`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-dlq-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-dlq-topic[`+++kafkastreamsprocessor.dlq.topic+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.dlq.topic+++[]
 endif::add-copy-button-to-config-props[]
@@ -336,7 +336,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-dlq-cloud-event-serializer-config-cloud-event-serializer-config]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-dlq-cloud-event-serializer-config-cloud-event-serializer-config[`kafkastreamsprocessor.dlq.cloud-event-serializer-config."cloud-event-serializer-config"`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-dlq-cloud-event-serializer-config-cloud-event-serializer-config]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-dlq-cloud-event-serializer-config-cloud-event-serializer-config[`+++kafkastreamsprocessor.dlq.cloud-event-serializer-config."cloud-event-serializer-config"+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.dlq.cloud-event-serializer-config."cloud-event-serializer-config"+++[]
 endif::add-copy-button-to-config-props[]
@@ -359,7 +359,7 @@ endif::add-copy-button-to-env-var[]
 |Map<String,String>
 |
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-global-dlq-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-global-dlq-topic[`kafkastreamsprocessor.global-dlq.topic`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-global-dlq-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-global-dlq-topic[`+++kafkastreamsprocessor.global-dlq.topic+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.global-dlq.topic+++[]
 endif::add-copy-button-to-config-props[]
@@ -380,7 +380,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-global-dlq-max-message-size]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-global-dlq-max-message-size[`kafkastreamsprocessor.global-dlq.max-message-size`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-global-dlq-max-message-size]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-global-dlq-max-message-size[`+++kafkastreamsprocessor.global-dlq.max-message-size+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.global-dlq.max-message-size+++[]
 endif::add-copy-button-to-config-props[]
@@ -403,7 +403,7 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++2147483647+++`
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-error-strategy]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-error-strategy[`kafkastreamsprocessor.error-strategy`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-error-strategy]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-error-strategy[`+++kafkastreamsprocessor.error-strategy+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.error-strategy+++[]
 endif::add-copy-button-to-config-props[]
@@ -415,9 +415,9 @@ Kafka error handling strategy.
 
 Possible values are:
 
- - `continue`: (default) drop the message and continue processing
- - `dead-letter-queue`: send the message to the DLQ and continue processing
- - `fail`: (not implemented yet) fail and stop processing more message
+ * `continue`: (default) drop the message and continue processing
+ * `dead-letter-queue`: send the message to the DLQ and continue processing
+ * `fail`: (not implemented yet) fail and stop processing more message
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -430,7 +430,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++continue+++`
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-max-retries]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-max-retries[`kafkastreamsprocessor.retry.max-retries`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-max-retries]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-max-retries[`+++kafkastreamsprocessor.retry.max-retries+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.retry.max-retries+++[]
 endif::add-copy-button-to-config-props[]
@@ -451,7 +451,7 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++-1+++`
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-delay]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-delay[`kafkastreamsprocessor.retry.delay`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-delay]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-delay[`+++kafkastreamsprocessor.retry.delay+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.retry.delay+++[]
 endif::add-copy-button-to-config-props[]
@@ -472,7 +472,7 @@ endif::add-copy-button-to-env-var[]
 |long
 |`+++0+++`
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-delay-unit]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-delay-unit[`kafkastreamsprocessor.retry.delay-unit`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-delay-unit]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-delay-unit[`+++kafkastreamsprocessor.retry.delay-unit+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.retry.delay-unit+++[]
 endif::add-copy-button-to-config-props[]
@@ -495,7 +495,7 @@ endif::add-copy-button-to-env-var[]
 a|`nanos`, `micros`, `millis`, `seconds`, `minutes`, `hours`, `half-days`, `days`, `weeks`, `months`, `years`, `decades`, `centuries`, `millennia`, `eras`, `forever`
 |`+++millis+++`
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-max-duration]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-max-duration[`kafkastreamsprocessor.retry.max-duration`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-max-duration]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-max-duration[`+++kafkastreamsprocessor.retry.max-duration+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.retry.max-duration+++[]
 endif::add-copy-button-to-config-props[]
@@ -516,7 +516,7 @@ endif::add-copy-button-to-env-var[]
 |long
 |`+++180000+++`
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-duration-unit]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-duration-unit[`kafkastreamsprocessor.retry.duration-unit`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-duration-unit]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-duration-unit[`+++kafkastreamsprocessor.retry.duration-unit+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.retry.duration-unit+++[]
 endif::add-copy-button-to-config-props[]
@@ -539,7 +539,7 @@ endif::add-copy-button-to-env-var[]
 a|`nanos`, `micros`, `millis`, `seconds`, `minutes`, `hours`, `half-days`, `days`, `weeks`, `months`, `years`, `decades`, `centuries`, `millennia`, `eras`, `forever`
 |`+++millis+++`
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-jitter]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-jitter[`kafkastreamsprocessor.retry.jitter`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-jitter]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-jitter[`+++kafkastreamsprocessor.retry.jitter+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.retry.jitter+++[]
 endif::add-copy-button-to-config-props[]
@@ -560,7 +560,7 @@ endif::add-copy-button-to-env-var[]
 |long
 |`+++200+++`
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-jitter-delay-unit]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-jitter-delay-unit[`kafkastreamsprocessor.retry.jitter-delay-unit`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-jitter-delay-unit]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-jitter-delay-unit[`+++kafkastreamsprocessor.retry.jitter-delay-unit+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.retry.jitter-delay-unit+++[]
 endif::add-copy-button-to-config-props[]
@@ -583,7 +583,7 @@ endif::add-copy-button-to-env-var[]
 a|`nanos`, `micros`, `millis`, `seconds`, `minutes`, `hours`, `half-days`, `days`, `weeks`, `months`, `years`, `decades`, `centuries`, `millennia`, `eras`, `forever`
 |`+++millis+++`
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-retry-on]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-retry-on[`kafkastreamsprocessor.retry.retry-on`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-retry-on]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-retry-on[`+++kafkastreamsprocessor.retry.retry-on+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.retry.retry-on+++[]
 endif::add-copy-button-to-config-props[]
@@ -606,7 +606,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |`+++io.quarkiverse.kafkastreamsprocessor.api.exception.RetryableException+++`
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-abort-on]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-abort-on[`kafkastreamsprocessor.retry.abort-on`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-abort-on]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-abort-on[`+++kafkastreamsprocessor.retry.abort-on+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.retry.abort-on+++[]
 endif::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-kafka-streams-processor_kafkastreamsprocessor.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-kafka-streams-processor_kafkastreamsprocessor.adoc
@@ -7,7 +7,7 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-input-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-input-topic[`kafkastreamsprocessor.input.topic`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-input-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-input-topic[`+++kafkastreamsprocessor.input.topic+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.input.topic+++[]
 endif::add-copy-button-to-config-props[]
@@ -30,7 +30,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-input-topics]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-input-topics[`kafkastreamsprocessor.input.topics`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-input-topics]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-input-topics[`+++kafkastreamsprocessor.input.topics+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.input.topics+++[]
 endif::add-copy-button-to-config-props[]
@@ -53,7 +53,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-input-sources-sources-topics]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-input-sources-sources-topics[`kafkastreamsprocessor.input.sources."sources".topics`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-input-sources-sources-topics]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-input-sources-sources-topics[`+++kafkastreamsprocessor.input.sources."sources".topics+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.input.sources."sources".topics+++[]
 endif::add-copy-button-to-config-props[]
@@ -74,7 +74,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |required icon:exclamation-circle[title=Configuration property is required]
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-input-is-cloud-event]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-input-is-cloud-event[`kafkastreamsprocessor.input.is-cloud-event`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-input-is-cloud-event]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-input-is-cloud-event[`+++kafkastreamsprocessor.input.is-cloud-event+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.input.is-cloud-event+++[]
 endif::add-copy-button-to-config-props[]
@@ -95,7 +95,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-input-cloud-event-deserializer-config-cloud-event-deserializer-config]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-input-cloud-event-deserializer-config-cloud-event-deserializer-config[`kafkastreamsprocessor.input.cloud-event-deserializer-config."cloud-event-deserializer-config"`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-input-cloud-event-deserializer-config-cloud-event-deserializer-config]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-input-cloud-event-deserializer-config-cloud-event-deserializer-config[`+++kafkastreamsprocessor.input.cloud-event-deserializer-config."cloud-event-deserializer-config"+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.input.cloud-event-deserializer-config."cloud-event-deserializer-config"+++[]
 endif::add-copy-button-to-config-props[]
@@ -120,7 +120,7 @@ endif::add-copy-button-to-env-var[]
 |Map<String,String>
 |
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-topic[`kafkastreamsprocessor.output.topic`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-topic[`+++kafkastreamsprocessor.output.topic+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.output.topic+++[]
 endif::add-copy-button-to-config-props[]
@@ -141,7 +141,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-sinks-sinks-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-sinks-sinks-topic[`kafkastreamsprocessor.output.sinks."sinks".topic`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-sinks-sinks-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-sinks-sinks-topic[`+++kafkastreamsprocessor.output.sinks."sinks".topic+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.output.sinks."sinks".topic+++[]
 endif::add-copy-button-to-config-props[]
@@ -162,7 +162,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |required icon:exclamation-circle[title=Configuration property is required]
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-is-cloud-event]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-is-cloud-event[`kafkastreamsprocessor.output.is-cloud-event`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-is-cloud-event]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-is-cloud-event[`+++kafkastreamsprocessor.output.is-cloud-event+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.output.is-cloud-event+++[]
 endif::add-copy-button-to-config-props[]
@@ -183,7 +183,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-event-serializer-config-cloud-event-serializer-config]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-event-serializer-config-cloud-event-serializer-config[`kafkastreamsprocessor.output.cloud-event-serializer-config."cloud-event-serializer-config"`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-event-serializer-config-cloud-event-serializer-config]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-event-serializer-config-cloud-event-serializer-config[`+++kafkastreamsprocessor.output.cloud-event-serializer-config."cloud-event-serializer-config"+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.output.cloud-event-serializer-config."cloud-event-serializer-config"+++[]
 endif::add-copy-button-to-config-props[]
@@ -206,7 +206,7 @@ endif::add-copy-button-to-env-var[]
 |Map<String,String>
 |
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-type]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-type[`kafkastreamsprocessor.output.cloud-events-type`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-type]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-type[`+++kafkastreamsprocessor.output.cloud-events-type+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.output.cloud-events-type+++[]
 endif::add-copy-button-to-config-props[]
@@ -229,7 +229,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-source]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-source[`kafkastreamsprocessor.output.cloud-events-source`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-source]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-source[`+++kafkastreamsprocessor.output.cloud-events-source+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.output.cloud-events-source+++[]
 endif::add-copy-button-to-config-props[]
@@ -252,7 +252,7 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/net/URI.html[URI]
 |
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-spec-version]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-spec-version[`kafkastreamsprocessor.output.cloud-events-spec-version`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-spec-version]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-spec-version[`+++kafkastreamsprocessor.output.cloud-events-spec-version+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.output.cloud-events-spec-version+++[]
 endif::add-copy-button-to-config-props[]
@@ -273,7 +273,7 @@ endif::add-copy-button-to-env-var[]
 a|`v03`, `v1`
 |`+++v1+++`
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-insert-timestamp]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-insert-timestamp[`kafkastreamsprocessor.output.cloud-events-insert-timestamp`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-insert-timestamp]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-output-cloud-events-insert-timestamp[`+++kafkastreamsprocessor.output.cloud-events-insert-timestamp+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.output.cloud-events-insert-timestamp+++[]
 endif::add-copy-button-to-config-props[]
@@ -294,7 +294,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-global-stores-global-stores-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-global-stores-global-stores-topic[`kafkastreamsprocessor.global-stores."global-stores".topic`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-global-stores-global-stores-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-global-stores-global-stores-topic[`+++kafkastreamsprocessor.global-stores."global-stores".topic+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.global-stores."global-stores".topic+++[]
 endif::add-copy-button-to-config-props[]
@@ -315,7 +315,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |required icon:exclamation-circle[title=Configuration property is required]
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-dlq-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-dlq-topic[`kafkastreamsprocessor.dlq.topic`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-dlq-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-dlq-topic[`+++kafkastreamsprocessor.dlq.topic+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.dlq.topic+++[]
 endif::add-copy-button-to-config-props[]
@@ -336,7 +336,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-dlq-cloud-event-serializer-config-cloud-event-serializer-config]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-dlq-cloud-event-serializer-config-cloud-event-serializer-config[`kafkastreamsprocessor.dlq.cloud-event-serializer-config."cloud-event-serializer-config"`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-dlq-cloud-event-serializer-config-cloud-event-serializer-config]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-dlq-cloud-event-serializer-config-cloud-event-serializer-config[`+++kafkastreamsprocessor.dlq.cloud-event-serializer-config."cloud-event-serializer-config"+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.dlq.cloud-event-serializer-config."cloud-event-serializer-config"+++[]
 endif::add-copy-button-to-config-props[]
@@ -359,7 +359,7 @@ endif::add-copy-button-to-env-var[]
 |Map<String,String>
 |
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-global-dlq-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-global-dlq-topic[`kafkastreamsprocessor.global-dlq.topic`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-global-dlq-topic]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-global-dlq-topic[`+++kafkastreamsprocessor.global-dlq.topic+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.global-dlq.topic+++[]
 endif::add-copy-button-to-config-props[]
@@ -380,7 +380,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-global-dlq-max-message-size]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-global-dlq-max-message-size[`kafkastreamsprocessor.global-dlq.max-message-size`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-global-dlq-max-message-size]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-global-dlq-max-message-size[`+++kafkastreamsprocessor.global-dlq.max-message-size+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.global-dlq.max-message-size+++[]
 endif::add-copy-button-to-config-props[]
@@ -403,7 +403,7 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++2147483647+++`
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-error-strategy]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-error-strategy[`kafkastreamsprocessor.error-strategy`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-error-strategy]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-error-strategy[`+++kafkastreamsprocessor.error-strategy+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.error-strategy+++[]
 endif::add-copy-button-to-config-props[]
@@ -415,9 +415,9 @@ Kafka error handling strategy.
 
 Possible values are:
 
- - `continue`: (default) drop the message and continue processing
- - `dead-letter-queue`: send the message to the DLQ and continue processing
- - `fail`: (not implemented yet) fail and stop processing more message
+ * `continue`: (default) drop the message and continue processing
+ * `dead-letter-queue`: send the message to the DLQ and continue processing
+ * `fail`: (not implemented yet) fail and stop processing more message
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -430,7 +430,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++continue+++`
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-max-retries]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-max-retries[`kafkastreamsprocessor.retry.max-retries`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-max-retries]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-max-retries[`+++kafkastreamsprocessor.retry.max-retries+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.retry.max-retries+++[]
 endif::add-copy-button-to-config-props[]
@@ -451,7 +451,7 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++-1+++`
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-delay]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-delay[`kafkastreamsprocessor.retry.delay`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-delay]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-delay[`+++kafkastreamsprocessor.retry.delay+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.retry.delay+++[]
 endif::add-copy-button-to-config-props[]
@@ -472,7 +472,7 @@ endif::add-copy-button-to-env-var[]
 |long
 |`+++0+++`
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-delay-unit]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-delay-unit[`kafkastreamsprocessor.retry.delay-unit`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-delay-unit]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-delay-unit[`+++kafkastreamsprocessor.retry.delay-unit+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.retry.delay-unit+++[]
 endif::add-copy-button-to-config-props[]
@@ -495,7 +495,7 @@ endif::add-copy-button-to-env-var[]
 a|`nanos`, `micros`, `millis`, `seconds`, `minutes`, `hours`, `half-days`, `days`, `weeks`, `months`, `years`, `decades`, `centuries`, `millennia`, `eras`, `forever`
 |`+++millis+++`
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-max-duration]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-max-duration[`kafkastreamsprocessor.retry.max-duration`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-max-duration]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-max-duration[`+++kafkastreamsprocessor.retry.max-duration+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.retry.max-duration+++[]
 endif::add-copy-button-to-config-props[]
@@ -516,7 +516,7 @@ endif::add-copy-button-to-env-var[]
 |long
 |`+++180000+++`
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-duration-unit]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-duration-unit[`kafkastreamsprocessor.retry.duration-unit`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-duration-unit]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-duration-unit[`+++kafkastreamsprocessor.retry.duration-unit+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.retry.duration-unit+++[]
 endif::add-copy-button-to-config-props[]
@@ -539,7 +539,7 @@ endif::add-copy-button-to-env-var[]
 a|`nanos`, `micros`, `millis`, `seconds`, `minutes`, `hours`, `half-days`, `days`, `weeks`, `months`, `years`, `decades`, `centuries`, `millennia`, `eras`, `forever`
 |`+++millis+++`
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-jitter]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-jitter[`kafkastreamsprocessor.retry.jitter`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-jitter]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-jitter[`+++kafkastreamsprocessor.retry.jitter+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.retry.jitter+++[]
 endif::add-copy-button-to-config-props[]
@@ -560,7 +560,7 @@ endif::add-copy-button-to-env-var[]
 |long
 |`+++200+++`
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-jitter-delay-unit]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-jitter-delay-unit[`kafkastreamsprocessor.retry.jitter-delay-unit`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-jitter-delay-unit]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-jitter-delay-unit[`+++kafkastreamsprocessor.retry.jitter-delay-unit+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.retry.jitter-delay-unit+++[]
 endif::add-copy-button-to-config-props[]
@@ -583,7 +583,7 @@ endif::add-copy-button-to-env-var[]
 a|`nanos`, `micros`, `millis`, `seconds`, `minutes`, `hours`, `half-days`, `days`, `weeks`, `months`, `years`, `decades`, `centuries`, `millennia`, `eras`, `forever`
 |`+++millis+++`
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-retry-on]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-retry-on[`kafkastreamsprocessor.retry.retry-on`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-retry-on]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-retry-on[`+++kafkastreamsprocessor.retry.retry-on+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.retry.retry-on+++[]
 endif::add-copy-button-to-config-props[]
@@ -606,7 +606,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |`+++io.quarkiverse.kafkastreamsprocessor.api.exception.RetryableException+++`
 
-a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-abort-on]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-abort-on[`kafkastreamsprocessor.retry.abort-on`]##
+a| [[quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-abort-on]] [.property-path]##link:#quarkus-kafka-streams-processor_kafkastreamsprocessor-retry-abort-on[`+++kafkastreamsprocessor.retry.abort-on+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++kafkastreamsprocessor.retry.abort-on+++[]
 endif::add-copy-button-to-config-props[]

--- a/impl/src/main/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/DlqProducerService.java
+++ b/impl/src/main/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/DlqProducerService.java
@@ -33,9 +33,12 @@ import org.apache.kafka.common.Configurable;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.processor.TaskId;
 
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.context.Context;
 import io.quarkiverse.kafkastreamsprocessor.api.decorator.producer.ProducerOnSendInterceptor;
 import io.quarkiverse.kafkastreamsprocessor.impl.KafkaClientSupplierDecorator;
 import io.quarkiverse.kafkastreamsprocessor.impl.metrics.KafkaStreamsProcessorMetrics;
+import io.quarkiverse.kafkastreamsprocessor.propagation.KafkaTextMapSetter;
 import io.quarkiverse.kafkastreamsprocessor.spi.properties.KStreamsProcessorConfig;
 import lombok.extern.slf4j.Slf4j;
 
@@ -75,6 +78,10 @@ public class DlqProducerService implements Configurable {
     /** True if the dead letter queue strategy is selected and properly configured */
     boolean sendToDlq;
 
+    private final OpenTelemetry openTelemetry;
+
+    private final KafkaTextMapSetter kafkaTextMapSetter;
+
     /**
      * Injection constructor
      *
@@ -88,15 +95,24 @@ public class DlqProducerService implements Configurable {
     public DlqProducerService(KafkaClientSupplier kafkaClientSupplier,
             KafkaStreamsProcessorMetrics metrics,
             DlqMetadataHandler dlqMetadataHandler,
-            KStreamsProcessorConfig kStreamsProcessorConfig) {
+            KStreamsProcessorConfig kStreamsProcessorConfig,
+            OpenTelemetry openTelemetry,
+            KafkaTextMapSetter kafkaTextMapSetter) {
         this.clientSupplier = kafkaClientSupplier;
         this.metrics = metrics;
         this.dlqMetadataHandler = dlqMetadataHandler;
         this.kStreamsProcessorConfig = kStreamsProcessorConfig;
+        this.openTelemetry = openTelemetry;
+        this.kafkaTextMapSetter = kafkaTextMapSetter;
     }
 
     public void sendToDlq(final ConsumerRecord<byte[], byte[]> record, final Exception exception, TaskId taskId,
             Boolean isDeserializationException) {
+        openTelemetry.getPropagators().getTextMapPropagator().fields().forEach(record.headers()::remove);
+        openTelemetry.getPropagators()
+                .getTextMapPropagator()
+                .inject(Context.current(), record.headers(), kafkaTextMapSetter);
+
         metrics.microserviceDlqSentCounter().increment();
         log.error("Exception caught during {}, sending to the dead letter queue topic; " +
                 "taskId: {}, topic: {}, partition: {}, offset: {}",

--- a/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/DlqDecoratorQuarkusTest.java
+++ b/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/DlqDecoratorQuarkusTest.java
@@ -23,8 +23,10 @@ import static io.quarkiverse.kafkastreamsprocessor.impl.protocol.KafkaStreamsPro
 import static io.quarkiverse.kafkastreamsprocessor.impl.protocol.KafkaStreamsProcessorHeaders.DLQ_PARTITION;
 import static io.quarkiverse.kafkastreamsprocessor.impl.protocol.KafkaStreamsProcessorHeaders.DLQ_REASON;
 import static io.quarkiverse.kafkastreamsprocessor.impl.protocol.KafkaStreamsProcessorHeaders.DLQ_TOPIC;
+import static io.quarkiverse.kafkastreamsprocessor.impl.protocol.KafkaStreamsProcessorHeaders.W3C_TRACE_ID;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 import java.nio.charset.StandardCharsets;
@@ -167,13 +169,17 @@ public class DlqDecoratorQuarkusTest {
         ConsumerRecord<String, PingMessage.Ping> dlqRecord = dlqRecords.iterator().next();
         assertThat(dlqRecord.key(), equalTo("blabla"));
         assertThat(dlqRecord.value().getMessage(), equalTo(PROCESS_AND_FAIL_MESSAGE));
-        assertThat(dlqRecord.headers().toArray().length, equalTo(5));
+        assertThat(dlqRecord.headers().toArray().length, equalTo(6));
         assertThat(headerValue(dlqRecord, "header1"), equalTo("value"));
         assertThat(headerValue(dlqRecord, DLQ_REASON), equalTo("Processor code throwing exception"));
         assertThat(headerValue(dlqRecord, DLQ_CAUSE), equalTo("java.lang.Throwable"));
         assertThat(headerValue(dlqRecord, DLQ_PARTITION), equalTo("0"));
         assertThat(headerValue(dlqRecord, DLQ_TOPIC), equalTo(kStreamsProcessorConfig.input().topic().get()));
         assertThat(dlqRecord.headers().lastHeader(PRODUCER_INTERCEPTOR_ADDED_HEADER_NAME), nullValue());
+
+        // ensure trace headers were injected into the DLQ record; we expect only the headers configured by
+        // propagator to be actually propagated
+        assertThat(dlqRecord.headers().lastHeader(W3C_TRACE_ID), notNullValue());
 
         ((OpenTelemetrySdk) openTelemetry).getSdkTracerProvider().forceFlush().join(10, TimeUnit.SECONDS);
 
@@ -195,12 +201,15 @@ public class DlqDecoratorQuarkusTest {
         ConsumerRecord<String, PingMessage.Ping> dlqRecord = dlqRecords.iterator().next();
         assertThat(dlqRecord.key(), equalTo("blabla"));
         assertThat(dlqRecord.value().getMessage(), equalTo(INTERCEPT_AND_FAIL_MESSAGE));
-        assertThat(dlqRecord.headers().toArray().length, equalTo(4));
+        assertThat(dlqRecord.headers().toArray().length, equalTo(5));
         assertThat(headerValue(dlqRecord, DLQ_REASON), equalTo("Interceptor code throwing exception"));
         assertThat(headerValue(dlqRecord, DLQ_CAUSE), equalTo("java.lang.Throwable"));
         assertThat(headerValue(dlqRecord, DLQ_PARTITION), equalTo("0"));
         assertThat(headerValue(dlqRecord, DLQ_TOPIC), equalTo(kStreamsProcessorConfig.input().topic().get()));
         assertThat(dlqRecord.headers().lastHeader(PRODUCER_INTERCEPTOR_ADDED_HEADER_NAME), nullValue());
+
+        // ensure trace headers were injected into the DLQ record
+        assertThat(dlqRecord.headers().lastHeader(W3C_TRACE_ID), notNullValue());
 
         ((OpenTelemetrySdk) openTelemetry).getSdkTracerProvider().forceFlush().join(10, TimeUnit.SECONDS);
 

--- a/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/DlqProducerServiceTest.java
+++ b/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/DlqProducerServiceTest.java
@@ -19,12 +19,14 @@
  */
 package io.quarkiverse.kafkastreamsprocessor.impl.errors;
 
+import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -47,9 +49,14 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.quarkiverse.kafkastreamsprocessor.impl.KafkaClientSupplierDecorator;
 import io.quarkiverse.kafkastreamsprocessor.impl.metrics.KafkaStreamsProcessorMetrics;
 import io.quarkiverse.kafkastreamsprocessor.impl.metrics.MockKafkaStreamsProcessorMetrics;
+import io.quarkiverse.kafkastreamsprocessor.propagation.KafkaTextMapSetter;
 import io.quarkiverse.kafkastreamsprocessor.spi.properties.DlqConfig;
 import io.quarkiverse.kafkastreamsprocessor.spi.properties.KStreamsProcessorConfig;
 
@@ -74,6 +81,18 @@ class DlqProducerServiceTest {
     KStreamsProcessorConfig kStreamsProcessorConfig;
 
     @Mock
+    OpenTelemetry openTelemetry;
+
+    @Mock
+    ContextPropagators contextPropagators;
+
+    @Mock
+    TextMapPropagator textMapPropagator;
+
+    @Mock
+    KafkaTextMapSetter kafkaTextMapSetter;
+
+    @Mock
     DlqConfig dlqConfig;
 
     @Mock
@@ -92,7 +111,8 @@ class DlqProducerServiceTest {
     @BeforeEach
     void setUp() {
         when(kStreamsProcessorConfig.dlq()).thenReturn(dlqConfig);
-        service = new DlqProducerService(kafkaClientSupplier, metrics, dlqMetadataHandler, kStreamsProcessorConfig);
+        service = new DlqProducerService(kafkaClientSupplier, metrics, dlqMetadataHandler, kStreamsProcessorConfig,
+                openTelemetry, kafkaTextMapSetter);
     }
 
     @Test
@@ -132,6 +152,9 @@ class DlqProducerServiceTest {
         when(dlqConfig.topic()).thenReturn(Optional.of(DLQ_TOPIC));
         when(kStreamsProcessorConfig.errorStrategy()).thenReturn(ErrorHandlingStrategy.DEAD_LETTER_QUEUE);
         when(kafkaClientSupplier.getProducer(any())).thenReturn(dlqProducer);
+        when(openTelemetry.getPropagators()).thenReturn(contextPropagators);
+        when(contextPropagators.getTextMapPropagator()).thenReturn(textMapPropagator);
+        when(textMapPropagator.fields()).thenReturn(singletonList("traceparent"));
         RecordHeaders enrichedHeaders = new RecordHeaders();
         when(dlqMetadataHandler.withMetadata(any(), any(), any(), any())).thenReturn(enrichedHeaders);
         when(consumerRecord.topic()).thenReturn(SOURCE_TOPIC);
@@ -140,7 +163,8 @@ class DlqProducerServiceTest {
         when(consumerRecord.timestamp()).thenReturn(TIMESTAMP);
         when(consumerRecord.key()).thenReturn(KEY);
         when(consumerRecord.value()).thenReturn(VALUE);
-        when(consumerRecord.headers()).thenReturn(new RecordHeaders());
+        RecordHeaders originalHeaders = new RecordHeaders();
+        when(consumerRecord.headers()).thenReturn(originalHeaders);
 
         //Call configure first to initialize properly the dlq producer
         service.configure(Collections.emptyMap());
@@ -155,6 +179,9 @@ class DlqProducerServiceTest {
         assertThat(sentRecord.value(), is(VALUE));
         assertThat(sentRecord.timestamp(), is(TIMESTAMP));
         assertThat(sentRecord.headers(), is(enrichedHeaders));
+
+        // ensure propagator injected headers into the record.headers()
+        verify(textMapPropagator).inject(any(Context.class), eq(originalHeaders), eq(kafkaTextMapSetter));
     }
 
     @Test
@@ -163,7 +190,11 @@ class DlqProducerServiceTest {
         when(kStreamsProcessorConfig.errorStrategy()).thenReturn(ErrorHandlingStrategy.DEAD_LETTER_QUEUE);
         when(kafkaClientSupplier.getProducer(any())).thenReturn(dlqProducer);
         when(dlqMetadataHandler.withMetadata(any(), any(), any(), any())).thenReturn(new RecordHeaders());
-        when(consumerRecord.headers()).thenReturn(new RecordHeaders());
+        when(openTelemetry.getPropagators()).thenReturn(contextPropagators);
+        when(contextPropagators.getTextMapPropagator()).thenReturn(textMapPropagator);
+        when(textMapPropagator.fields()).thenReturn(singletonList("traceparent"));
+        RecordHeaders headers = new RecordHeaders();
+        when(consumerRecord.headers()).thenReturn(headers);
         when(consumerRecord.timestamp()).thenReturn(TIMESTAMP);
 
         //Call configure first to initialize properly the dlq producer
@@ -172,6 +203,9 @@ class DlqProducerServiceTest {
         service.sendToDlq(consumerRecord, new RuntimeException("error"), new TaskId(0, PARTITION), false);
 
         assertThat(metrics.microserviceDlqSentCounter().count(), closeTo(1d, 0.01d));
+
+        // verify openTelemetry headers injection
+        verify(textMapPropagator).inject(any(Context.class), eq(headers), eq(kafkaTextMapSetter));
     }
 
     @Test
@@ -179,6 +213,9 @@ class DlqProducerServiceTest {
         when(dlqConfig.topic()).thenReturn(Optional.of(DLQ_TOPIC));
         when(kStreamsProcessorConfig.errorStrategy()).thenReturn(ErrorHandlingStrategy.DEAD_LETTER_QUEUE);
         when(kafkaClientSupplier.getProducer(any())).thenReturn(dlqProducer);
+        when(openTelemetry.getPropagators()).thenReturn(contextPropagators);
+        when(contextPropagators.getTextMapPropagator()).thenReturn(textMapPropagator);
+        when(textMapPropagator.fields()).thenReturn(singletonList("traceparent"));
         RecordHeaders originalHeaders = new RecordHeaders();
         when(dlqMetadataHandler.withMetadata(any(), any(), any(), any())).thenReturn(new RecordHeaders());
         when(consumerRecord.topic()).thenReturn(SOURCE_TOPIC);

--- a/integration-tests/consumer/pom.xml
+++ b/integration-tests/consumer/pom.xml
@@ -148,5 +148,10 @@
             <artifactId>quarkus-kafka-streams-processor-test-framework</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/integration-tests/consumer/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/consumer/ConsumerProcessorQuarkusTest.java
+++ b/integration-tests/consumer/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/consumer/ConsumerProcessorQuarkusTest.java
@@ -20,8 +20,11 @@
 package io.quarkiverse.kafkastreamsprocessor.sample.consumer;
 
 import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.is;
 
+import java.time.Duration;
 import java.util.Map;
 
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -64,21 +67,26 @@ public class ConsumerProcessorQuarkusTest {
     @Test
     public void shouldStoreConsumedEvents() throws Exception {
         // Ensure the storage is empty before the test
-        given().when().delete("/cached-events")
-                .then().statusCode(200);
-        given().when().get("/cached-events")
-                .then().statusCode(200)
+        given().when()
+                .delete("/cached-events")
+                .then()
+                .statusCode(200);
+        given().when()
+                .get("/cached-events")
+                .then()
+                .statusCode(200)
                 .body(is("No events cached"));
 
         producer.send(new ProducerRecord<>(senderTopic, "MyEventKey", "{ \"value\": \"Hello, World!\" }"));
         producer.flush();
 
-        // Wait for the event to be processed
-        Thread.sleep(1000);
-
-        given()
-                .when().get("/cached-events")
-                .then().statusCode(200)
-                .body(is("Key: MyEventKey, Value: MyData[value=Hello, World!]\n"));
+        await().atMost(Duration.ofSeconds(10))
+                .until(() -> "Key: MyEventKey, Value: MyData[value=Hello, World!]\n".equals(
+                        when().get("/cached-events")
+                                .then()
+                                .statusCode(200)
+                                .extract()
+                                .body()
+                                .asString()));
     }
 }

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -29,6 +29,7 @@
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
+        <extensions>true</extensions>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
Fix issue where trace context headers (e.g., traceparent) were lost when records were sent to DLQ.

when records are sent to the DLQ. DLQ producers intentionally skip `ProducerOnSendInterceptor`, so tracing headers were not reinjected during DLQ sends, this commit explicitly injects the OpenTelemetry propagator into the DLQ send to preserve trace continuity. 

DLQ producers are created with dlq.producer=true

Cause #233
Fixes #274