### PR TITLE
feat: change spring-kafka-test for KafkaCompanion

### DIFF
--- a/adr/cloud-events-generic-type.patch
+++ b/adr/cloud-events-generic-type.patch
@@ -413,8 +413,7 @@ index 0000000..e0e0790
 +import org.junit.jupiter.api.AfterEach;
 +import org.junit.jupiter.api.BeforeEach;
 +import org.junit.jupiter.api.Test;
-+import org.springframework.kafka.test.utils.KafkaTestUtils;
-+
+++
 +import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufDeserializer;
 +import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufSerializer;
 +
@@ -539,8 +538,7 @@ index 0000000..3c2bf39
 +import org.junit.jupiter.api.AfterEach;
 +import org.junit.jupiter.api.BeforeEach;
 +import org.junit.jupiter.api.Test;
-+import org.springframework.kafka.test.utils.KafkaTestUtils;
-+
+++
 +/**
 + * Blackbox test that can run both in JVM and native modes (@Inject and @ConfigProperty not allowed)
 + */

--- a/adr/cloud-events-integrated.patch
+++ b/adr/cloud-events-integrated.patch
@@ -716,8 +716,7 @@ index 0000000..4b03593
 +import org.junit.jupiter.api.AfterEach;
 +import org.junit.jupiter.api.BeforeEach;
 +import org.junit.jupiter.api.Test;
-+import org.springframework.kafka.test.utils.KafkaTestUtils;
-+
+++
 +import io.cloudevents.CloudEvent;
 +import io.cloudevents.core.v1.CloudEventBuilder;
 +import io.cloudevents.kafka.CloudEventDeserializer;

--- a/bom/test/pom.xml
+++ b/bom/test/pom.xml
@@ -47,25 +47,6 @@
         <version>6.0.0</version>
       </dependency>
       <dependency>
-        <groupId>org.springframework.kafka</groupId>
-        <artifactId>spring-kafka-test</artifactId>
-        <version>4.0.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-metadata</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.13</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-clients</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
         <groupId>org.apache.kafka</groupId>
         <artifactId>kafka-metadata</artifactId>
         <version>${kafka.version}</version>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -236,8 +236,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.springframework.kafka</groupId>
-      <artifactId>spring-kafka-test</artifactId>
+      <groupId>io.smallrye.reactive</groupId>
+      <artifactId>smallrye-reactive-messaging-kafka-test-companion</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -307,6 +307,16 @@
     <dependency>
       <groupId>io.cloudevents</groupId>
       <artifactId>cloudevents-json-jackson</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye.reactive</groupId>
+      <artifactId>smallrye-reactive-messaging-kafka-test-companion</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-test-kafka-companion</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/CloudEventQuarkusTest.java
+++ b/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/CloudEventQuarkusTest.java
@@ -32,7 +32,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -41,8 +40,7 @@ import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -52,7 +50,6 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.v1.CloudEventBuilder;
@@ -61,13 +58,20 @@ import io.cloudevents.kafka.CloudEventSerializer;
 import io.quarkiverse.kafkastreamsprocessor.api.Processor;
 import io.quarkiverse.kafkastreamsprocessor.api.cloudevents.CloudEventContextHandler;
 import io.quarkiverse.kafkastreamsprocessor.sample.message.PingMessage;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder;
 import lombok.extern.slf4j.Slf4j;
 
 @QuarkusTest
 @TestProfile(CloudEventQuarkusTest.TestProfile.class)
+@QuarkusTestResource(KafkaCompanionResource.class)
 public class CloudEventQuarkusTest {
     private static final String DLQ_TOPIC_NAME = "dlq-topic";
     private static final String PROCESS_AND_FAIL_MESSAGE = "Process&Fail";
@@ -78,34 +82,24 @@ public class CloudEventQuarkusTest {
     @ConfigProperty(name = "kafkastreamsprocessor.output.topic")
     String consumerTopic;
 
-    @ConfigProperty(name = "kafka.bootstrap.servers")
-    String bootstrapServers;
+    @InjectKafkaCompanion
+    KafkaCompanion companion;
 
-    KafkaProducer<String, CloudEvent> producer;
+    ProducerBuilder<String, CloudEvent> producer;
 
-    KafkaConsumer<String, CloudEvent> consumer;
-
-    KafkaConsumer<String, CloudEvent> dlqConsumer;
+    ConsumerBuilder<String, CloudEvent> consumer;
 
     @BeforeEach
     public void setup() {
-        producer = new KafkaProducer<>(KafkaTestUtils.producerProps(bootstrapServers), new StringSerializer(),
-                new CloudEventSerializer());
-
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(bootstrapServers, "test", true);
-        consumer = new KafkaConsumer<>(consumerProps, new StringDeserializer(), new CloudEventDeserializer());
-        consumer.subscribe(List.of(consumerTopic));
-
-        Map<String, Object> dlqConsumerProps = KafkaTestUtils.consumerProps(bootstrapServers, "dlq", true);
-        dlqConsumer = new KafkaConsumer<>(dlqConsumerProps, new StringDeserializer(), new CloudEventDeserializer());
-        dlqConsumer.subscribe(List.of(DLQ_TOPIC_NAME));
+        producer = companion.produceWithSerializers(new StringSerializer(), new CloudEventSerializer());
+        consumer = companion.consumeWithDeserializers(new StringDeserializer(), new CloudEventDeserializer())
+                .withGroupId("test").withOffsetReset(OffsetResetStrategy.EARLIEST.toString()).withAutoCommit();
     }
 
     @AfterEach
     public void tearDown() throws Exception {
         producer.close();
         consumer.close();
-        dlqConsumer.close();
     }
 
     @Test
@@ -118,11 +112,10 @@ public class CloudEventQuarkusTest {
                 .build();
         ProducerRecord<String, CloudEvent> sentRecord = new ProducerRecord<>(senderTopic, 0, "key", cloudEvent);
 
-        producer.send(sentRecord);
-        producer.flush();
+        producer.fromRecords(sentRecord).awaitCompletion(Duration.ofSeconds(5));
 
-        ConsumerRecord<String, CloudEvent> singleRecord = KafkaTestUtils.getSingleRecord(consumer, consumerTopic,
-                Duration.ofSeconds(10));
+        ConsumerRecord<String, CloudEvent> singleRecord = consumer.fromTopics(consumerTopic, 1)
+                .awaitCompletion(Duration.ofSeconds(10)).getFirstRecord();
 
         assertThat(singleRecord.key(), equalTo("key"));
         assertThat(PingMessage.Ping.parseFrom(singleRecord.value().getData().toBytes()).getMessage(), equalTo("blabla"));
@@ -144,11 +137,10 @@ public class CloudEventQuarkusTest {
                 .build();
         ProducerRecord<String, CloudEvent> sentRecord = new ProducerRecord<>(senderTopic, 0, "key", cloudEvent);
 
-        producer.send(sentRecord);
-        producer.flush();
+        producer.fromRecords(sentRecord).awaitCompletion(Duration.ofSeconds(5));
 
-        ConsumerRecord<String, CloudEvent> dlqRecord = KafkaTestUtils.getSingleRecord(dlqConsumer, DLQ_TOPIC_NAME,
-                Duration.ofSeconds(10));
+        ConsumerRecord<String, CloudEvent> dlqRecord = consumer.fromTopics(DLQ_TOPIC_NAME, 1)
+                .awaitCompletion(Duration.ofSeconds(10)).getFirstRecord();
 
         assertThat(dlqRecord.key(), equalTo("key"));
         assertThat(PingMessage.Ping.parseFrom(dlqRecord.value().getData().toBytes()).getMessage(),

--- a/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/CloudEventTimestampQuarkusTest.java
+++ b/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/CloudEventTimestampQuarkusTest.java
@@ -27,7 +27,6 @@ import static org.hamcrest.Matchers.nullValue;
 import java.net.URI;
 import java.time.Duration;
 import java.time.OffsetDateTime;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -36,8 +35,7 @@ import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -47,7 +45,6 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.v1.CloudEventBuilder;
@@ -56,13 +53,20 @@ import io.cloudevents.kafka.CloudEventSerializer;
 import io.quarkiverse.kafkastreamsprocessor.api.Processor;
 import io.quarkiverse.kafkastreamsprocessor.api.cloudevents.CloudEventContextHandler;
 import io.quarkiverse.kafkastreamsprocessor.sample.message.PingMessage;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder;
 import lombok.extern.slf4j.Slf4j;
 
 @QuarkusTest
 @TestProfile(CloudEventTimestampQuarkusTest.DisabledTimestampProfile.class)
+@QuarkusTestResource(KafkaCompanionResource.class)
 public class CloudEventTimestampQuarkusTest {
     @ConfigProperty(name = "kafkastreamsprocessor.input.topic")
     String senderTopic;
@@ -70,20 +74,18 @@ public class CloudEventTimestampQuarkusTest {
     @ConfigProperty(name = "kafkastreamsprocessor.output.topic")
     String consumerTopic;
 
-    @ConfigProperty(name = "kafka.bootstrap.servers")
-    String bootstrapServers;
+    @InjectKafkaCompanion
+    KafkaCompanion companion;
 
-    KafkaProducer<String, CloudEvent> producer;
+    ProducerBuilder<String, CloudEvent> producer;
 
-    KafkaConsumer<String, CloudEvent> consumer;
+    ConsumerBuilder<String, CloudEvent> consumer;
 
     @BeforeEach
     public void setup() {
-        producer = new KafkaProducer<>(KafkaTestUtils.producerProps(bootstrapServers), new StringSerializer(),
-                new CloudEventSerializer());
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(bootstrapServers, "test-timestamp", "true");
-        consumer = new KafkaConsumer<>(consumerProps, new StringDeserializer(), new CloudEventDeserializer());
-        consumer.subscribe(List.of(consumerTopic));
+        producer = companion.produceWithSerializers(new StringSerializer(), new CloudEventSerializer());
+        consumer = companion.consumeWithDeserializers(new StringDeserializer(), new CloudEventDeserializer())
+                .withGroupId("test").withOffsetReset(OffsetResetStrategy.EARLIEST.toString()).withAutoCommit();
     }
 
     @AfterEach
@@ -102,11 +104,10 @@ public class CloudEventTimestampQuarkusTest {
                 .build();
         ProducerRecord<String, CloudEvent> sentRecord = new ProducerRecord<>(senderTopic, 0, "key", cloudEvent);
 
-        producer.send(sentRecord);
-        producer.flush();
+        producer.fromRecords(sentRecord).awaitCompletion(Duration.ofSeconds(5));
 
-        ConsumerRecord<String, CloudEvent> singleRecord = KafkaTestUtils.getSingleRecord(consumer, consumerTopic,
-                Duration.ofSeconds(10));
+        ConsumerRecord<String, CloudEvent> singleRecord = consumer.fromTopics(consumerTopic, 1)
+                .awaitCompletion(Duration.ofSeconds(10)).getFirstRecord();
 
         assertThat(singleRecord.key(), equalTo("key"));
         assertThat(PingMessage.Ping.parseFrom(singleRecord.value().getData().toBytes()).getMessage(),
@@ -126,11 +127,10 @@ public class CloudEventTimestampQuarkusTest {
                 .build();
         ProducerRecord<String, CloudEvent> sentRecord = new ProducerRecord<>(senderTopic, 0, "key", cloudEvent);
 
-        producer.send(sentRecord);
-        producer.flush();
+        producer.fromRecords(sentRecord).awaitCompletion(Duration.ofSeconds(5));
 
-        ConsumerRecord<String, CloudEvent> singleRecord = KafkaTestUtils.getSingleRecord(consumer, consumerTopic,
-                Duration.ofSeconds(10));
+        ConsumerRecord<String, CloudEvent> singleRecord = consumer.fromTopics(consumerTopic, 1)
+                .awaitCompletion(Duration.ofSeconds(10)).getFirstRecord();
 
         assertThat(singleRecord.key(), equalTo("key"));
         assertThat(PingMessage.Ping.parseFrom(singleRecord.value().getData().toBytes()).getMessage(),

--- a/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/CustomKeyTypeSupportedQuarkusTest.java
+++ b/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/CustomKeyTypeSupportedQuarkusTest.java
@@ -23,7 +23,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import java.time.Duration;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -32,8 +31,7 @@ import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
@@ -47,20 +45,26 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import io.opentelemetry.api.trace.Tracer;
 import io.quarkiverse.kafkastreamsprocessor.api.Processor;
 import io.quarkiverse.kafkastreamsprocessor.api.configuration.Configuration;
 import io.quarkiverse.kafkastreamsprocessor.api.configuration.ConfigurationCustomizer;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 
 @QuarkusTest
 @TestProfile(CustomKeyTypeSupportedQuarkusTest.TestProfile.class)
+@QuarkusTestResource(KafkaCompanionResource.class)
 public class CustomKeyTypeSupportedQuarkusTest {
     @ConfigProperty(name = "kafkastreamsprocessor.input.topic")
     String senderTopic;
@@ -68,20 +72,18 @@ public class CustomKeyTypeSupportedQuarkusTest {
     @ConfigProperty(name = "kafkastreamsprocessor.output.topic")
     String consumerTopic;
 
-    @ConfigProperty(name = "kafka.bootstrap.servers")
-    String bootstrapServers;
+    @InjectKafkaCompanion
+    KafkaCompanion companion;
 
-    KafkaProducer<KeyType, String> producer;
+    ProducerBuilder<KeyType, String> producer;
 
-    KafkaConsumer<KeyType, String> consumer;
+    ConsumerBuilder<KeyType, String> consumer;
 
     @BeforeEach
     public void setup() {
-        producer = new KafkaProducer<>(KafkaTestUtils.producerProps(bootstrapServers), new KeySerializer(),
-                new StringSerializer());
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(bootstrapServers, "test", "true");
-        consumer = new KafkaConsumer<>(consumerProps, new KeyDeserializer(), new StringDeserializer());
-        consumer.subscribe(List.of(consumerTopic));
+        producer = companion.produceWithSerializers(new KeySerializer(), new StringSerializer());
+        consumer = companion.consumeWithDeserializers(new KeyDeserializer(), new StringDeserializer())
+                .withGroupId("test").withOffsetReset(OffsetResetStrategy.EARLIEST.toString()).withAutoCommit();
     }
 
     @AfterEach
@@ -94,11 +96,10 @@ public class CustomKeyTypeSupportedQuarkusTest {
     public void customKeyTypeSupported() {
         ProducerRecord<KeyType, String> sentRecord = new ProducerRecord<>(senderTopic, 0, new KeyType("key"), "value");
 
-        producer.send(sentRecord);
-        producer.flush();
+        producer.fromRecords(sentRecord).awaitCompletion(Duration.ofSeconds(5));
 
-        ConsumerRecord<KeyType, String> singleRecord = KafkaTestUtils.getSingleRecord(consumer, consumerTopic,
-                Duration.ofSeconds(10));
+        ConsumerRecord<KeyType, String> singleRecord = consumer.fromTopics(consumerTopic, 1)
+                .awaitCompletion(Duration.ofSeconds(10)).getFirstRecord();
 
         assertThat(singleRecord.key().getKey(), equalTo("key$"));
         assertThat(singleRecord.value(), equalTo("valueg"));

--- a/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/MultipleSourcesQuarkusTest.java
+++ b/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/MultipleSourcesQuarkusTest.java
@@ -21,7 +21,7 @@ package io.quarkiverse.kafkastreamsprocessor.impl;
 
 import static io.quarkiverse.kafkastreamsprocessor.sample.message.PingMessage.Ping;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 
 import java.time.Duration;
 import java.util.List;
@@ -30,32 +30,36 @@ import java.util.Set;
 
 import jakarta.enterprise.inject.Alternative;
 
-import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.processor.api.ContextualProcessor;
 import org.apache.kafka.streams.processor.api.Record;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufDeserializer;
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufSerializer;
 
 import io.quarkiverse.kafkastreamsprocessor.api.Processor;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder;
 import lombok.extern.slf4j.Slf4j;
 
 @QuarkusTest
 @TestProfile(MultipleSourcesQuarkusTest.TestProfile.class)
 @Slf4j
+@QuarkusTestResource(KafkaCompanionResource.class)
 public class MultipleSourcesQuarkusTest {
     // @ConfigProperty can't be used as it will clash with other
     // test cases (the annotations are checked even if no test cases
@@ -64,19 +68,18 @@ public class MultipleSourcesQuarkusTest {
     String[] pangTopics = new String[] { "pang-topic" };
     String pongTopic = "pong-topic";
 
-    @ConfigProperty(name = "kafka.bootstrap.servers")
-    String bootstrapServers;
-    KafkaProducer<String, Ping> producer;
+    @InjectKafkaCompanion
+    KafkaCompanion companion;
 
-    KafkaConsumer<String, Ping> consumer;
+    ProducerBuilder<String, Ping> producer;
+
+    ConsumerBuilder<String, Ping> consumer;
 
     @BeforeEach
     public void setup() {
-        producer = new KafkaProducer(KafkaTestUtils.producerProps(bootstrapServers), new StringSerializer(),
-                new KafkaProtobufSerializer<>());
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(bootstrapServers, "test", "true");
-        consumer = new KafkaConsumer(consumerProps, new StringDeserializer(),
-                new KafkaProtobufDeserializer<>(Ping.parser()));
+        producer = companion.produceWithSerializers(new StringSerializer(), new KafkaProtobufSerializer<>());
+        consumer = companion.consumeWithDeserializers(new StringDeserializer(), new KafkaProtobufDeserializer<>(Ping.parser()))
+                .withGroupId("test").withOffsetReset(OffsetResetStrategy.EARLIEST.toString()).withAutoCommit();
     }
 
     @AfterEach
@@ -88,19 +91,18 @@ public class MultipleSourcesQuarkusTest {
     @Test
     public void whenProducingFromEachInputTopic_shouldProduce() {
 
-        consumer.subscribe(List.of(pongTopic));
+        // use topic(s) in List.of(pongTopic) with consumer.fromTopics at consumption time
 
         Ping ping = Ping.newBuilder().setMessage("world").build();
 
-        producer.send(new ProducerRecord<>(pingTopics[0], null, ping));
-        producer.send(new ProducerRecord<>(pingTopics[1], null, ping));
-        producer.send(new ProducerRecord<>(pangTopics[0], null, ping));
-        producer.flush();
+        producer.fromRecords(new ProducerRecord<>(pingTopics[0], null, ping)).awaitCompletion(Duration.ofSeconds(1));
+        producer.fromRecords(new ProducerRecord<>(pingTopics[1], null, ping)).awaitCompletion(Duration.ofSeconds(1));
+        producer.fromRecords(new ProducerRecord<>(pangTopics[0], null, ping)).awaitCompletion(Duration.ofSeconds(1));
 
-        ConsumerRecords<String, Ping> records = KafkaTestUtils.getRecords(consumer,
-                Duration.ofSeconds(10), 3);
+        List<ConsumerRecord<String, Ping>> records = consumer.fromTopics(pongTopic, 3).awaitCompletion(Duration.ofSeconds(10))
+                .getRecords();
 
-        assertThat(records.count(), equalTo(3));
+        assertThat(records, hasSize(3));
     }
 
     @Processor

--- a/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/TracingBaggageAndCustomSpanQuarkusTest.java
+++ b/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/TracingBaggageAndCustomSpanQuarkusTest.java
@@ -25,16 +25,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 
 import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.Map;
+import java.time.Duration;
 import java.util.Set;
 
 import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -45,7 +43,6 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufDeserializer;
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufSerializer;
@@ -63,13 +60,20 @@ import io.quarkiverse.kafkastreamsprocessor.api.Processor;
 import io.quarkiverse.kafkastreamsprocessor.impl.utils.TestSpanExporter;
 import io.quarkiverse.kafkastreamsprocessor.propagation.KafkaTextMapSetter;
 import io.quarkiverse.kafkastreamsprocessor.sample.message.PingMessage;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder;
 import lombok.extern.slf4j.Slf4j;
 
 @QuarkusTest
 @TestProfile(TracingBaggageAndCustomSpanQuarkusTest.TestProfile.class)
+@QuarkusTestResource(KafkaCompanionResource.class)
 public class TracingBaggageAndCustomSpanQuarkusTest {
     @ConfigProperty(name = "kafkastreamsprocessor.input.topic")
     String senderTopic;
@@ -77,12 +81,12 @@ public class TracingBaggageAndCustomSpanQuarkusTest {
     @ConfigProperty(name = "kafkastreamsprocessor.output.topic")
     String consumerTopic;
 
-    @ConfigProperty(name = "kafka.bootstrap.servers")
-    String bootstrapServers;
+    @InjectKafkaCompanion
+    KafkaCompanion companion;
 
-    KafkaProducer<String, PingMessage.Ping> producer;
+    ProducerBuilder<String, PingMessage.Ping> producer;
 
-    KafkaConsumer<String, PingMessage.Ping> consumer;
+    ConsumerBuilder<String, PingMessage.Ping> consumer;
 
     @Inject
     OpenTelemetry openTelemetry;
@@ -98,13 +102,10 @@ public class TracingBaggageAndCustomSpanQuarkusTest {
 
     @BeforeEach
     public void setup() {
-        producer = new KafkaProducer<>(KafkaTestUtils.producerProps(bootstrapServers), new StringSerializer(),
-                new KafkaProtobufSerializer<>());
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(bootstrapServers, "test", "true");
-        consumer = new KafkaConsumer<>(consumerProps, new StringDeserializer(),
-                new KafkaProtobufDeserializer<>(PingMessage.Ping.parser()));
-        consumer.subscribe(List.of(consumerTopic));
-
+        producer = companion.produceWithSerializers(new StringSerializer(), new KafkaProtobufSerializer<>());
+        consumer = companion
+                .consumeWithDeserializers(new StringDeserializer(), new KafkaProtobufDeserializer<>(PingMessage.Ping.parser()))
+                .withGroupId("test").withOffsetReset(OffsetResetStrategy.EARLIEST.toString()).withAutoCommit();
         clearSpans();
     }
 
@@ -135,10 +136,9 @@ public class TracingBaggageAndCustomSpanQuarkusTest {
             ProducerRecord<String, PingMessage.Ping> sentRecord = new ProducerRecord<>(senderTopic, 0, "key", input,
                     recordHeaders);
 
-            producer.send(sentRecord);
-            producer.flush();
+            producer.fromRecords(sentRecord).awaitCompletion(Duration.ofSeconds(5));
 
-            receivedRecord = KafkaTestUtils.getSingleRecord(consumer, consumerTopic);
+            receivedRecord = consumer.fromTopics(consumerTopic, 1).awaitCompletion(Duration.ofSeconds(5)).getFirstRecord();
 
             assertThat(getHeader(receivedRecord, "baggage"), containsString("key1=value1"));
             assertThat(getHeader(receivedRecord, "baggage"), containsString("key2=value2"));

--- a/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/TracingQuarkusTest.java
+++ b/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/TracingQuarkusTest.java
@@ -28,7 +28,6 @@ import static org.hamcrest.Matchers.hasEntry;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -36,8 +35,7 @@ import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeaders;
@@ -49,7 +47,6 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufDeserializer;
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufSerializer;
@@ -66,13 +63,20 @@ import io.quarkiverse.kafkastreamsprocessor.impl.protocol.KafkaStreamsProcessorH
 import io.quarkiverse.kafkastreamsprocessor.impl.utils.TestSpanExporter;
 import io.quarkiverse.kafkastreamsprocessor.propagation.KafkaTextMapSetter;
 import io.quarkiverse.kafkastreamsprocessor.sample.message.PingMessage;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder;
 import lombok.extern.slf4j.Slf4j;
 
 @QuarkusTest
 @TestProfile(TracingQuarkusTest.TestProfile.class)
+@QuarkusTestResource(KafkaCompanionResource.class)
 public class TracingQuarkusTest {
     @ConfigProperty(name = "kafkastreamsprocessor.input.topic")
     String senderTopic;
@@ -80,12 +84,12 @@ public class TracingQuarkusTest {
     @ConfigProperty(name = "kafkastreamsprocessor.output.topic")
     String consumerTopic;
 
-    @ConfigProperty(name = "kafka.bootstrap.servers")
-    String bootstrapServers;
+    @InjectKafkaCompanion
+    KafkaCompanion kafkaCompanion;
 
-    KafkaProducer<String, PingMessage.Ping> producer;
+    ProducerBuilder<String, PingMessage.Ping> producer;
 
-    KafkaConsumer<String, PingMessage.Ping> consumer;
+    ConsumerBuilder<String, PingMessage.Ping> consumer;
 
     @Inject
     OpenTelemetry openTelemetry;
@@ -101,13 +105,10 @@ public class TracingQuarkusTest {
 
     @BeforeEach
     public void setup() {
-        producer = new KafkaProducer<>(KafkaTestUtils.producerProps(bootstrapServers), new StringSerializer(),
-                new KafkaProtobufSerializer<>());
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(bootstrapServers, "test", "true");
-        consumer = new KafkaConsumer<>(consumerProps, new StringDeserializer(),
-                new KafkaProtobufDeserializer<>(PingMessage.Ping.parser()));
-        consumer.subscribe(List.of(consumerTopic));
-
+        producer = kafkaCompanion.produceWithSerializers(new StringSerializer(), new KafkaProtobufSerializer<>());
+        consumer = kafkaCompanion.consumeWithDeserializers(new StringDeserializer(),
+                new KafkaProtobufDeserializer<>(PingMessage.Ping.parser()))
+                .withGroupId("test").withOffsetReset(OffsetResetStrategy.EARLIEST.toString()).withAutoCommit();
         clearSpans();
     }
 
@@ -134,10 +135,10 @@ public class TracingQuarkusTest {
                     .getTextMapPropagator()
                     .inject(Context.current(), headers, kafkaTextMapSetter);
             ProducerRecord<String, PingMessage.Ping> record = new ProducerRecord<>(senderTopic, 0, "key", input, headers);
-            producer.send(record);
+            producer.fromRecords(record).awaitCompletion(Duration.ofSeconds(5));
 
-            ConsumerRecord<String, PingMessage.Ping> singleRecord = KafkaTestUtils.getSingleRecord(consumer, consumerTopic,
-                    Duration.ofSeconds(5));
+            ConsumerRecord<String, PingMessage.Ping> singleRecord = consumer.fromTopics(consumerTopic, 1)
+                    .awaitCompletion(Duration.ofSeconds(5)).getFirstRecord();
             assertThat(toMap(singleRecord.headers()),
                     hasEntry(equalTo(KafkaStreamsProcessorHeaders.W3C_TRACE_ID),
                             containsString(parentSpan.getSpanContext().getTraceId())));
@@ -165,9 +166,9 @@ public class TracingQuarkusTest {
                     .getTextMapPropagator()
                     .inject(Context.current(), headers, kafkaTextMapSetter);
             ProducerRecord<String, PingMessage.Ping> record = new ProducerRecord<>(senderTopic, 0, "key", input, headers);
-            producer.send(record);
+            producer.fromRecords(record).awaitCompletion(Duration.ofSeconds(5));
 
-            KafkaTestUtils.getSingleRecord(consumer, consumerTopic, Duration.ofSeconds(5));
+            consumer.fromTopics(consumerTopic, 1).awaitCompletion(Duration.ofSeconds(5));
         } finally {
             parentSpan.end();
         }

--- a/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/decorator/processor/CdiRequestContextDecoratorQuarkusTest.java
+++ b/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/decorator/processor/CdiRequestContextDecoratorQuarkusTest.java
@@ -26,22 +26,18 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import jakarta.inject.Inject;
 
-import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufDeserializer;
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufSerializer;
@@ -49,33 +45,36 @@ import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufSerializer;
 import io.quarkiverse.kafkastreamsprocessor.impl.decorator.request.RequestScopeConsumerProcessor;
 import io.quarkiverse.kafkastreamsprocessor.sample.message.PingMessage;
 import io.quarkiverse.kafkastreamsprocessor.spi.properties.KStreamsProcessorConfig;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder;
 
 @QuarkusTest
 @TestProfile(CdiRequestContextDecoratorQuarkusTest.CdiRequestContextTestProfile.class)
+@QuarkusTestResource(KafkaCompanionResource.class)
 public class CdiRequestContextDecoratorQuarkusTest {
     @Inject
     KStreamsProcessorConfig kStreamsProcessorConfig;
 
-    @ConfigProperty(name = "kafka.bootstrap.servers")
-    String kafkaBootstrapServers;
+    @InjectKafkaCompanion
+    KafkaCompanion kafkaCompanion;
 
-    KafkaProducer<String, PingMessage.Ping> producer;
+    ProducerBuilder<String, PingMessage.Ping> producer;
 
-    KafkaConsumer<String, PingMessage.Ping> consumer;
+    ConsumerBuilder<String, PingMessage.Ping> consumer;
 
     @BeforeEach
     public void setup() {
-        producer = new KafkaProducer<>(KafkaTestUtils.producerProps(kafkaBootstrapServers),
-                new StringSerializer(),
-                new KafkaProtobufSerializer<>());
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(kafkaBootstrapServers,
-                "test", "true");
-        consumer = new KafkaConsumer<>(consumerProps, new StringDeserializer(),
-                new KafkaProtobufDeserializer<>(PingMessage.Ping.parser()));
-        consumer.subscribe(List.of(kStreamsProcessorConfig.output().topic().get()));
+        producer = kafkaCompanion.produceWithSerializers(new StringSerializer(), new KafkaProtobufSerializer<>());
+        consumer = kafkaCompanion
+                .consumeWithDeserializers(new StringDeserializer(), new KafkaProtobufDeserializer<>(PingMessage.Ping.parser()))
+                .withGroupId("test").withOffsetReset(OffsetResetStrategy.EARLIEST.toString()).withAutoCommit();
     }
 
     @AfterEach
@@ -89,12 +88,15 @@ public class CdiRequestContextDecoratorQuarkusTest {
         // The processor forwards a message containing "processorUuid:requestScopedBeanUuid"
         // Call it twice to verify that the requestScopedBeanUuid changes
         PingMessage.Ping ping = PingMessage.Ping.newBuilder().setMessage("Hello world").build();
-        producer.send(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(), ping));
-        producer.send(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(), ping));
-        producer.flush();
+        producer.fromRecords(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(), ping))
+                .awaitCompletion(Duration.ofSeconds(1));
+        producer.fromRecords(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(), ping))
+                .awaitCompletion(Duration.ofSeconds(1));
 
-        ConsumerRecords<String, PingMessage.Ping> consumerRecords = KafkaTestUtils.getRecords(consumer, Duration.ofSeconds(10),
-                2);
+        List<ConsumerRecord<String, PingMessage.Ping>> consumerRecords = consumer
+                .fromTopics(kStreamsProcessorConfig.output().topic().get(), 2)
+                .awaitCompletion(Duration.ofSeconds(10))
+                .getRecords();
 
         String[] records = stream(consumerRecords.spliterator(), false)
                 .map(record -> record.value().getMessage())

--- a/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/decorator/processor/OutputRecordInterceptionDecoratorQuarkusTest.java
+++ b/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/decorator/processor/OutputRecordInterceptionDecoratorQuarkusTest.java
@@ -5,8 +5,6 @@ import static org.hamcrest.Matchers.equalTo;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -14,19 +12,16 @@ import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.processor.api.ContextualProcessor;
 import org.apache.kafka.streams.processor.api.Record;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufDeserializer;
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufSerializer;
@@ -35,33 +30,38 @@ import io.quarkiverse.kafkastreamsprocessor.api.Processor;
 import io.quarkiverse.kafkastreamsprocessor.api.decorator.outputrecord.OutputRecordInterceptor;
 import io.quarkiverse.kafkastreamsprocessor.sample.message.PingMessage;
 import io.quarkiverse.kafkastreamsprocessor.spi.properties.KStreamsProcessorConfig;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder;
 
 @QuarkusTest
 @TestProfile(OutputRecordInterceptionDecoratorQuarkusTest.TestProfile.class)
+@QuarkusTestResource(KafkaCompanionResource.class)
 class OutputRecordInterceptionDecoratorQuarkusTest {
     @Inject
     KStreamsProcessorConfig kStreamsProcessorConfig;
 
-    @ConfigProperty(name = "kafka.bootstrap.servers")
-    String kafkaBootstrapServers;
+    @InjectKafkaCompanion
+    KafkaCompanion companion;
 
-    KafkaProducer<String, PingMessage.Ping> producer;
+    ProducerBuilder<String, PingMessage.Ping> producer;
 
-    KafkaConsumer<String, PingMessage.Ping> consumer;
+    ConsumerBuilder<String, PingMessage.Ping> consumer;
 
     @BeforeEach
     public void setup() {
-        producer = new KafkaProducer<>(KafkaTestUtils.producerProps(kafkaBootstrapServers),
-                new StringSerializer(),
-                new KafkaProtobufSerializer<>());
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(kafkaBootstrapServers,
-                "test", "true");
-        consumer = new KafkaConsumer<>(consumerProps, new StringDeserializer(),
-                new KafkaProtobufDeserializer<>(PingMessage.Ping.parser()));
-        consumer.subscribe(List.of(kStreamsProcessorConfig.output().topic().get()));
+        producer = companion.produceWithSerializers(new StringSerializer(), new KafkaProtobufSerializer<>());
+        consumer = companion
+                .consumeWithDeserializers(new StringDeserializer(), new KafkaProtobufDeserializer<>(PingMessage.Ping.parser()))
+                .withGroupId("test")
+                .withOffsetReset(OffsetResetStrategy.EARLIEST.toString())
+                .withAutoCommit();
     }
 
     @AfterEach
@@ -73,12 +73,14 @@ class OutputRecordInterceptionDecoratorQuarkusTest {
     @Test
     void forwardDecoratorCalledInOrder() {
         PingMessage.Ping ping = PingMessage.Ping.newBuilder().setMessage("Hello world").build();
-        producer.send(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(), 0, "blabla", ping,
-                new RecordHeaders().add("header1", "header2".getBytes(StandardCharsets.UTF_8))));
-        producer.flush();
+        producer.fromRecords(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(), 0, "blabla", ping,
+                new RecordHeaders().add("header1", "header2".getBytes(StandardCharsets.UTF_8))))
+                .awaitCompletion(Duration.ofSeconds(1));
 
-        ConsumerRecord<String, PingMessage.Ping> consumerRecord = KafkaTestUtils.getSingleRecord(consumer,
-                kStreamsProcessorConfig.output().topic().get(), Duration.ofSeconds(10));
+        ConsumerRecord<String, PingMessage.Ping> consumerRecord = consumer
+                .fromTopics(kStreamsProcessorConfig.output().topic().get(), 1)
+                .awaitCompletion(Duration.ofSeconds(10))
+                .getFirstRecord();
 
         assertThat(consumerRecord.key(), equalTo("blablase"));
         assertThat(consumerRecord.value().getMessage(), equalTo("Hello worldse"));
@@ -105,7 +107,8 @@ class OutputRecordInterceptionDecoratorQuarkusTest {
         @Override
         public Record interceptOutputRecord(Record record) {
             return record.withKey(record.key() + "s")
-                    .withValue(PingMessage.Ping.newBuilder().setMessage(((PingMessage.Ping) record.value()).getMessage() + "s")
+                    .withValue(PingMessage.Ping.newBuilder()
+                            .setMessage(((PingMessage.Ping) record.value()).getMessage() + "s")
                             .build())
                     .withHeaders(record.headers().add("blabla", "blibli".getBytes(StandardCharsets.UTF_8)));
         }
@@ -122,7 +125,8 @@ class OutputRecordInterceptionDecoratorQuarkusTest {
         @Override
         public Record interceptOutputRecord(Record record) {
             return record.withKey(record.key() + "e")
-                    .withValue(PingMessage.Ping.newBuilder().setMessage(((PingMessage.Ping) record.value()).getMessage() + "e")
+                    .withValue(PingMessage.Ping.newBuilder()
+                            .setMessage(((PingMessage.Ping) record.value()).getMessage() + "e")
                             .build())
                     .withHeaders(record.headers().add("blibli", "blabla".getBytes(StandardCharsets.UTF_8)));
         }

--- a/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/decorator/processor/VertxContextDecoratorQuarkusTest.java
+++ b/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/decorator/processor/VertxContextDecoratorQuarkusTest.java
@@ -6,26 +6,21 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.time.Duration;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.processor.api.ContextualProcessor;
 import org.apache.kafka.streams.processor.api.Record;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufDeserializer;
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufSerializer;
@@ -33,37 +28,42 @@ import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufSerializer;
 import io.quarkiverse.kafkastreamsprocessor.api.Processor;
 import io.quarkiverse.kafkastreamsprocessor.sample.message.PingMessage;
 import io.quarkiverse.kafkastreamsprocessor.spi.properties.KStreamsProcessorConfig;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
 import io.smallrye.common.vertx.ContextLocals;
 import io.smallrye.common.vertx.VertxContext;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder;
 import io.vertx.core.Vertx;
 
 @QuarkusTest
 @TestProfile(VertxContextDecoratorQuarkusTest.VertxContextTestProfile.class)
+@QuarkusTestResource(KafkaCompanionResource.class)
 public class VertxContextDecoratorQuarkusTest {
 
     @Inject
     KStreamsProcessorConfig kStreamsProcessorConfig;
 
-    @ConfigProperty(name = "kafka.bootstrap.servers")
-    String kafkaBootstrapServers;
+    @InjectKafkaCompanion
+    KafkaCompanion kafkaCompanion;
 
-    KafkaProducer<String, PingMessage.Ping> producer;
+    ProducerBuilder<String, PingMessage.Ping> producer;
 
-    KafkaConsumer<String, PingMessage.Ping> consumer;
+    ConsumerBuilder<String, PingMessage.Ping> consumer;
 
     @BeforeEach
     public void setup() {
-        producer = new KafkaProducer<>(KafkaTestUtils.producerProps(kafkaBootstrapServers),
-                new StringSerializer(),
-                new KafkaProtobufSerializer<>());
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(kafkaBootstrapServers,
-                "test", "true");
-        consumer = new KafkaConsumer<>(consumerProps, new StringDeserializer(),
-                new KafkaProtobufDeserializer<>(PingMessage.Ping.parser()));
-        consumer.subscribe(List.of(kStreamsProcessorConfig.output().topic().get()));
+        producer = kafkaCompanion.produceWithSerializers(new StringSerializer(), new KafkaProtobufSerializer<>());
+        consumer = kafkaCompanion.consumeWithDeserializers(new StringDeserializer(),
+                new KafkaProtobufDeserializer<>(PingMessage.Ping.parser()))
+                .withGroupId("test")
+                .withOffsetReset(OffsetResetStrategy.EARLIEST.toString())
+                .withAutoCommit();
     }
 
     @AfterEach
@@ -76,11 +76,12 @@ public class VertxContextDecoratorQuarkusTest {
     public void shouldRunProcessorInVertxDuplicatedContext() {
         PingMessage.Ping ping = PingMessage.Ping.newBuilder().setMessage("world").build();
 
-        producer.send(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(), ping));
-        producer.flush();
+        producer.fromRecords(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(), ping))
+                .awaitCompletion(Duration.ofSeconds(1));
 
-        ConsumerRecord<String, PingMessage.Ping> consumerRecord = KafkaTestUtils.getSingleRecord(consumer,
-                kStreamsProcessorConfig.output().topic().get(), Duration.ofSeconds(10));
+        ConsumerRecord<String, PingMessage.Ping> consumerRecord = consumer
+                .fromTopics(kStreamsProcessorConfig.output().topic().get(), 1)
+                .awaitCompletion(Duration.ofSeconds(10)).getFirstRecord();
     }
 
     @Processor

--- a/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/decorator/producer/OrderedProducerInterceptorQuarkusTest.java
+++ b/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/decorator/producer/OrderedProducerInterceptorQuarkusTest.java
@@ -21,11 +21,11 @@ package io.quarkiverse.kafkastreamsprocessor.impl.decorator.producer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -33,18 +33,14 @@ import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.processor.api.ContextualProcessor;
 import org.apache.kafka.streams.processor.api.Record;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufDeserializer;
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufSerializer;
@@ -53,45 +49,56 @@ import io.quarkiverse.kafkastreamsprocessor.api.Processor;
 import io.quarkiverse.kafkastreamsprocessor.api.decorator.producer.ProducerOnSendInterceptor;
 import io.quarkiverse.kafkastreamsprocessor.sample.message.PingMessage;
 import io.quarkiverse.kafkastreamsprocessor.spi.properties.KStreamsProcessorConfig;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder;
 
 @QuarkusTest
 @TestProfile(OrderedProducerInterceptorQuarkusTest.TestProfile.class)
+@QuarkusTestResource(KafkaCompanionResource.class)
 public class OrderedProducerInterceptorQuarkusTest {
 
-    @ConfigProperty(name = "kafka.bootstrap.servers")
-    String bootstrapServers;
+    @InjectKafkaCompanion
+    KafkaCompanion companion;
 
     @Inject
     KStreamsProcessorConfig kStreamsProcessorConfig;
 
-    KafkaProducer<String, PingMessage.Ping> producer;
+    ProducerBuilder<String, PingMessage.Ping> producer;
 
-    KafkaConsumer<String, PingMessage.Ping> consumer;
+    ConsumerBuilder<String, PingMessage.Ping> consumer;
 
     @BeforeEach
     public void setup() {
-        producer = new KafkaProducer(KafkaTestUtils.producerProps(bootstrapServers), new StringSerializer(),
+        producer = companion.produceWithSerializers(new StringSerializer(),
                 new KafkaProtobufSerializer<>());
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(bootstrapServers, "test", "true");
-        consumer = new KafkaConsumer(consumerProps, new StringDeserializer(),
-                new KafkaProtobufDeserializer<>(PingMessage.Ping.parser()));
+
+        consumer = companion.consumeWithDeserializers(new StringDeserializer(),
+                new KafkaProtobufDeserializer<>(PingMessage.Ping.parser()))
+                .withGroupId("test")
+                .withOffsetReset(OffsetResetStrategy.EARLIEST.toString())
+                .withAutoCommit();
     }
 
     @Test
     public void producerInterceptorCalled() throws Exception {
-        consumer.subscribe(List.of(kStreamsProcessorConfig.output().topic().get()));
+        // use topic(s) in List.of(kStreamsProcessorConfig.output().topic().get()) with consumer.fromTopics at consumption
+        // time
 
-        producer.send(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(), 0, "key",
-                PingMessage.Ping.newBuilder().setMessage("value").build()));
-        producer.flush();
+        producer.fromRecords(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(), 0, "key",
+                PingMessage.Ping.newBuilder().setMessage("value").build())).awaitCompletion(Duration.ofSeconds(1));
 
-        ConsumerRecords<String, PingMessage.Ping> out = KafkaTestUtils.getRecords(consumer, Duration.ofSeconds(10),
-                1);
+        List<ConsumerRecord<String, PingMessage.Ping>> out = consumer
+                .fromTopics(kStreamsProcessorConfig.output().topic().get(), 1)
+                .awaitCompletion(Duration.ofSeconds(10)).getRecords();
 
-        assertThat(out.count(), equalTo(1));
+        assertThat(out, hasSize(1));
         ConsumerRecord<String, PingMessage.Ping> outRecord = out.iterator().next();
         assertThat(outRecord.key(), equalTo("key"));
         assertThat(outRecord.value().getMessage(), equalTo("value"));

--- a/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/decorator/producer/ProducerInterceptorQuarkusTest.java
+++ b/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/decorator/producer/ProducerInterceptorQuarkusTest.java
@@ -21,11 +21,11 @@ package io.quarkiverse.kafkastreamsprocessor.impl.decorator.producer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -33,18 +33,14 @@ import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.processor.api.ContextualProcessor;
 import org.apache.kafka.streams.processor.api.Record;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufDeserializer;
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufSerializer;
@@ -53,44 +49,50 @@ import io.quarkiverse.kafkastreamsprocessor.api.Processor;
 import io.quarkiverse.kafkastreamsprocessor.api.decorator.producer.ProducerOnSendInterceptor;
 import io.quarkiverse.kafkastreamsprocessor.sample.message.PingMessage;
 import io.quarkiverse.kafkastreamsprocessor.spi.properties.KStreamsProcessorConfig;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder;
 
 @QuarkusTest
 @TestProfile(ProducerInterceptorQuarkusTest.TestProfile.class)
+@QuarkusTestResource(KafkaCompanionResource.class)
 public class ProducerInterceptorQuarkusTest {
+    @InjectKafkaCompanion
+    KafkaCompanion companion;
 
-    @ConfigProperty(name = "kafka.bootstrap.servers")
-    String bootstrapServers;
-    KafkaProducer<String, PingMessage.Ping> producer;
+    ProducerBuilder<String, PingMessage.Ping> producer;
 
-    KafkaConsumer<String, PingMessage.Ping> consumer;
+    ConsumerBuilder<String, PingMessage.Ping> consumer;
 
     @Inject
     KStreamsProcessorConfig kStreamsProcessorConfig;
 
     @BeforeEach
     public void setup() {
-        producer = new KafkaProducer(KafkaTestUtils.producerProps(bootstrapServers), new StringSerializer(),
+        producer = companion.produceWithSerializers(new StringSerializer(),
                 new KafkaProtobufSerializer<>());
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(bootstrapServers, "test", "true");
-        consumer = new KafkaConsumer(consumerProps, new StringDeserializer(),
-                new KafkaProtobufDeserializer<>(PingMessage.Ping.parser()));
+
+        consumer = companion.consumeWithDeserializers(new StringDeserializer(),
+                new KafkaProtobufDeserializer<>(PingMessage.Ping.parser())).withGroupId("test")
+                .withOffsetReset(OffsetResetStrategy.EARLIEST.toString()).withAutoCommit();
     }
 
     @Test
     public void producerInterceptorCalled() throws Exception {
-        consumer.subscribe(List.of(kStreamsProcessorConfig.output().topic().get()));
+        producer.fromRecords(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(), 0, "key",
+                PingMessage.Ping.newBuilder().setMessage("value").build())).awaitCompletion(Duration.ofSeconds(1));
 
-        producer.send(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(), 0, "key",
-                PingMessage.Ping.newBuilder().setMessage("value").build()));
-        producer.flush();
+        List<ConsumerRecord<String, PingMessage.Ping>> out = consumer
+                .fromTopics(kStreamsProcessorConfig.output().topic().get(), 1)
+                .awaitCompletion(Duration.ofSeconds(10)).getRecords();
 
-        ConsumerRecords<String, PingMessage.Ping> out = KafkaTestUtils.getRecords(consumer, Duration.ofSeconds(10),
-                1);
-
-        assertThat(out.count(), equalTo(1));
+        assertThat(out, hasSize(1));
         ConsumerRecord<String, PingMessage.Ping> outRecord = out.iterator().next();
         assertThat(outRecord.key(), equalTo("key"));
         assertThat(outRecord.value().getMessage(), equalTo("value"));

--- a/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/DlqDecoratorQuarkusTest.java
+++ b/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/DlqDecoratorQuarkusTest.java
@@ -31,7 +31,6 @@ import static org.hamcrest.Matchers.nullValue;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -43,20 +42,16 @@ import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.processor.api.ContextualProcessor;
 import org.apache.kafka.streams.processor.api.Record;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufDeserializer;
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufSerializer;
@@ -71,12 +66,19 @@ import io.quarkiverse.kafkastreamsprocessor.api.decorator.processor.ProcessorDec
 import io.quarkiverse.kafkastreamsprocessor.impl.utils.TestSpanExporter;
 import io.quarkiverse.kafkastreamsprocessor.sample.message.PingMessage;
 import io.quarkiverse.kafkastreamsprocessor.spi.properties.KStreamsProcessorConfig;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder;
 
 @QuarkusTest
 @TestProfile(DlqDecoratorQuarkusTest.TestProfile.class)
+@QuarkusTestResource(KafkaCompanionResource.class)
 public class DlqDecoratorQuarkusTest {
     private static final String DLQ_TOPIC_NAME = "dlq-topic";
     private static final String INTERCEPT_AND_FAIL_MESSAGE = "Intercept&Fail";
@@ -87,14 +89,12 @@ public class DlqDecoratorQuarkusTest {
     @Inject
     KStreamsProcessorConfig kStreamsProcessorConfig;
 
-    @ConfigProperty(name = "kafka.bootstrap.servers")
-    String kafkaBootstrapServers;
+    @InjectKafkaCompanion
+    KafkaCompanion companion;
 
-    KafkaProducer<String, PingMessage.Ping> producer;
+    ProducerBuilder<String, PingMessage.Ping> producer;
 
-    KafkaConsumer<String, PingMessage.Ping> consumer;
-
-    KafkaConsumer<String, PingMessage.Ping> dlqConsumer;
+    ConsumerBuilder<String, PingMessage.Ping> consumer;
 
     @Inject
     OpenTelemetry openTelemetry;
@@ -104,25 +104,16 @@ public class DlqDecoratorQuarkusTest {
 
     @BeforeEach
     public void setup() {
-        producer = new KafkaProducer<>(KafkaTestUtils.producerProps(kafkaBootstrapServers), new StringSerializer(),
-                new KafkaProtobufSerializer<>());
-
-        Map<String, Object> dlqConsumerProps = KafkaTestUtils.consumerProps(kafkaBootstrapServers, "dlq", true);
-        dlqConsumer = new KafkaConsumer<>(dlqConsumerProps, new StringDeserializer(),
-                new KafkaProtobufDeserializer<>(PingMessage.Ping.parser()));
-        dlqConsumer.subscribe(List.of(DLQ_TOPIC_NAME));
-
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(kafkaBootstrapServers, "test", true);
-        consumer = new KafkaConsumer<>(consumerProps, new StringDeserializer(),
-                new KafkaProtobufDeserializer<>(PingMessage.Ping.parser()));
-        consumer.subscribe(List.of(kStreamsProcessorConfig.output().topic().get()));
+        producer = companion.produceWithSerializers(new StringSerializer(), new KafkaProtobufSerializer<>());
+        consumer = companion.consumeWithDeserializers(new StringDeserializer(),
+                new KafkaProtobufDeserializer<>(PingMessage.Ping.parser()))
+                .withGroupId("test").withOffsetReset(OffsetResetStrategy.EARLIEST.toString()).withAutoCommit();
     }
 
     @AfterEach
     public void tearDown() {
         producer.close();
         consumer.close();
-        dlqConsumer.close();
         clearSpans();
     }
 
@@ -135,14 +126,13 @@ public class DlqDecoratorQuarkusTest {
     @Test
     void successFlowShouldNotGoInDlqTopic() {
         PingMessage.Ping ping = PingMessage.Ping.newBuilder().setMessage("Hello World").build();
-        producer.send(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(), 0, "blabla", ping));
-        producer.flush();
+        producer.fromRecords(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(), 0, "blabla", ping))
+                .awaitCompletion(Duration.ofSeconds(1));
 
-        ConsumerRecords<String, PingMessage.Ping> mirroredRecords = KafkaTestUtils.getRecords(consumer, Duration.ofSeconds(10),
-                1);
-        assertThat(mirroredRecords.count(), equalTo(1));
+        ConsumerRecord<String, PingMessage.Ping> mirroredRecord = consumer
+                .fromTopics(kStreamsProcessorConfig.output().topic().get(), 1)
+                .awaitCompletion(Duration.ofSeconds(10)).getFirstRecord();
 
-        ConsumerRecord<String, PingMessage.Ping> mirroredRecord = mirroredRecords.iterator().next();
         assertThat(mirroredRecord.key(), equalTo("blabla"));
         assertThat(mirroredRecord.value().getMessage(), equalTo("Hello World"));
         assertThat(headerValue(mirroredRecord, PRODUCER_INTERCEPTOR_ADDED_HEADER_NAME),
@@ -158,15 +148,13 @@ public class DlqDecoratorQuarkusTest {
     @Test
     void processorErrorShouldGoInDlqTopic() {
         PingMessage.Ping ping = PingMessage.Ping.newBuilder().setMessage(PROCESS_AND_FAIL_MESSAGE).build();
-        producer.send(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(), 0, "blabla", ping,
-                new RecordHeaders().add("header1", "value".getBytes(StandardCharsets.UTF_8))));
-        producer.flush();
+        producer.fromRecords(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(), 0, "blabla", ping,
+                new RecordHeaders().add("header1", "value".getBytes(StandardCharsets.UTF_8))))
+                .awaitCompletion(Duration.ofSeconds(1));
 
-        ConsumerRecords<String, PingMessage.Ping> dlqRecords = KafkaTestUtils.getRecords(dlqConsumer, Duration.ofSeconds(100),
-                1);
-        assertThat(dlqRecords.count(), equalTo(1));
+        ConsumerRecord<String, PingMessage.Ping> dlqRecord = consumer.fromTopics(DLQ_TOPIC_NAME, 1)
+                .awaitCompletion(Duration.ofSeconds(10)).getFirstRecord();
 
-        ConsumerRecord<String, PingMessage.Ping> dlqRecord = dlqRecords.iterator().next();
         assertThat(dlqRecord.key(), equalTo("blabla"));
         assertThat(dlqRecord.value().getMessage(), equalTo(PROCESS_AND_FAIL_MESSAGE));
         assertThat(dlqRecord.headers().toArray().length, equalTo(6));
@@ -191,14 +179,12 @@ public class DlqDecoratorQuarkusTest {
     @Test
     void interceptorErrorShouldGoInDlqTopic() {
         PingMessage.Ping ping = PingMessage.Ping.newBuilder().setMessage(INTERCEPT_AND_FAIL_MESSAGE).build();
-        producer.send(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(), 0, "blabla", ping));
-        producer.flush();
+        producer.fromRecords(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(), 0, "blabla", ping))
+                .awaitCompletion(Duration.ofSeconds(1));
 
-        ConsumerRecords<String, PingMessage.Ping> dlqRecords = KafkaTestUtils.getRecords(dlqConsumer, Duration.ofSeconds(10),
-                1);
-        assertThat(dlqRecords.count(), equalTo(1));
+        ConsumerRecord<String, PingMessage.Ping> dlqRecord = consumer.fromTopics(DLQ_TOPIC_NAME, 1)
+                .awaitCompletion(Duration.ofSeconds(10)).getFirstRecord();
 
-        ConsumerRecord<String, PingMessage.Ping> dlqRecord = dlqRecords.iterator().next();
         assertThat(dlqRecord.key(), equalTo("blabla"));
         assertThat(dlqRecord.value().getMessage(), equalTo(INTERCEPT_AND_FAIL_MESSAGE));
         assertThat(dlqRecord.headers().toArray().length, equalTo(5));

--- a/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/ErrorHandlingStrategyQuarkusTest.java
+++ b/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/ErrorHandlingStrategyQuarkusTest.java
@@ -24,27 +24,22 @@ import static org.hamcrest.Matchers.is;
 
 import java.time.Duration;
 import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.processor.api.ContextualProcessor;
 import org.apache.kafka.streams.processor.api.Record;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufDeserializer;
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufSerializer;
@@ -52,32 +47,37 @@ import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufSerializer;
 import io.quarkiverse.kafkastreamsprocessor.api.Processor;
 import io.quarkiverse.kafkastreamsprocessor.sample.message.PingMessage;
 import io.quarkiverse.kafkastreamsprocessor.spi.properties.KStreamsProcessorConfig;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder;
 
 @QuarkusTest
 @TestProfile(ErrorHandlingStrategyQuarkusTest.TestProfile.class)
+@QuarkusTestResource(KafkaCompanionResource.class)
 public class ErrorHandlingStrategyQuarkusTest {
 
     @Inject
     KStreamsProcessorConfig kStreamsProcessorConfig;
 
-    @ConfigProperty(name = "kafka.bootstrap.servers")
-    String kafkaBootstrapServers;
+    @InjectKafkaCompanion
+    KafkaCompanion companion;
 
-    KafkaProducer<String, PingMessage.Ping> producer;
+    ProducerBuilder<String, PingMessage.Ping> producer;
 
-    KafkaConsumer<String, PingMessage.Ping> consumer;
+    ConsumerBuilder<String, PingMessage.Ping> consumer;
 
     @BeforeEach
     void setup() {
-        producer = new KafkaProducer<>(KafkaTestUtils.producerProps(kafkaBootstrapServers), new StringSerializer(),
-                new KafkaProtobufSerializer<>());
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(kafkaBootstrapServers, "test", "true");
-        consumer = new KafkaConsumer<>(consumerProps, new StringDeserializer(),
-                new KafkaProtobufDeserializer<>(PingMessage.Ping.parser()));
-        consumer.subscribe(List.of(kStreamsProcessorConfig.output().topic().get()));
+        producer = companion.produceWithSerializers(new StringSerializer(), new KafkaProtobufSerializer<>());
+        consumer = companion.consumeWithDeserializers(new StringDeserializer(),
+                new KafkaProtobufDeserializer<>(PingMessage.Ping.parser()))
+                .withGroupId("test").withOffsetReset(OffsetResetStrategy.EARLIEST.toString()).withAutoCommit();
     }
 
     @AfterEach
@@ -90,12 +90,12 @@ public class ErrorHandlingStrategyQuarkusTest {
     void continueErrorStrategyShouldBeTheDefaultWhenProcessingFail() {
         PingMessage.Ping pingA = PingMessage.Ping.newBuilder().setMessage("a").build();
         PingMessage.Ping pingAB = PingMessage.Ping.newBuilder().setMessage("ab").build();
-        producer.send(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(), pingA));
-        producer.send(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(), pingAB));
-        producer.flush();
-        ConsumerRecord<String, PingMessage.Ping> record = KafkaTestUtils.getSingleRecord(consumer,
-                kStreamsProcessorConfig.output().topic().get(),
-                Duration.ofSeconds(5));
+        producer.fromRecords(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(), pingA))
+                .awaitCompletion(Duration.ofSeconds(1));
+        producer.fromRecords(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(), pingAB))
+                .awaitCompletion(Duration.ofSeconds(1));
+        ConsumerRecord<String, PingMessage.Ping> record = consumer.fromTopics(kStreamsProcessorConfig.output().topic().get(), 1)
+                .awaitCompletion(Duration.ofSeconds(5)).getFirstRecord();
         MatcherAssert.assertThat(record.value().getMessage(), is(equalTo("ab")));
     }
 

--- a/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/GlobalDLQProductionExceptionHandlerQuarkusTest.java
+++ b/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/GlobalDLQProductionExceptionHandlerQuarkusTest.java
@@ -22,7 +22,7 @@ package io.quarkiverse.kafkastreamsprocessor.impl.errors;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.Matchers.hasSize;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -33,19 +33,16 @@ import java.util.Set;
 import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
 
-import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.processor.api.ContextualProcessor;
 import org.apache.kafka.streams.processor.api.Record;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufDeserializer;
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufSerializer;
@@ -55,13 +52,20 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkiverse.kafkastreamsprocessor.api.Processor;
 import io.quarkiverse.kafkastreamsprocessor.sample.message.PingMessage;
 import io.quarkiverse.kafkastreamsprocessor.spi.properties.KStreamsProcessorConfig;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
 import io.restassured.http.ContentType;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder;
 
 @QuarkusTest
 @TestProfile(GlobalDLQProductionExceptionHandlerQuarkusTest.TestProfile.class)
+@QuarkusTestResource(KafkaCompanionResource.class)
 public class GlobalDLQProductionExceptionHandlerQuarkusTest {
     private static final String GLOBALDLQ_TOPIC = "dlq-topic";
 
@@ -70,30 +74,22 @@ public class GlobalDLQProductionExceptionHandlerQuarkusTest {
 
     String inputTopic;
 
-    @ConfigProperty(name = "kafka.bootstrap.servers")
-    String kafkaBootstrapServers;
+    @InjectKafkaCompanion
+    KafkaCompanion companion;
 
     @Inject
     MeterRegistry registry;
 
-    KafkaProducer<String, PingMessage.Ping> producer;
+    ProducerBuilder<String, PingMessage.Ping> producer;
 
-    KafkaConsumer<String, PingMessage.Ping> consumer;
-
-    KafkaConsumer<String, PingMessage.Ping> dlqConsumer;
+    ConsumerBuilder<String, PingMessage.Ping> consumer;
 
     @BeforeEach
     public void setup() {
-        producer = new KafkaProducer<>(KafkaTestUtils.producerProps(kafkaBootstrapServers), new StringSerializer(),
-                new KafkaProtobufSerializer<>());
-
-        Map<String, Object> dlqConsumerProps = KafkaTestUtils.consumerProps(kafkaBootstrapServers, "dlq", "true");
-        dlqConsumer = new KafkaConsumer<>(dlqConsumerProps, new StringDeserializer(),
-                new KafkaProtobufDeserializer<>(PingMessage.Ping.parser()));
-
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(kafkaBootstrapServers, "test", "true");
-        consumer = new KafkaConsumer<>(consumerProps, new StringDeserializer(),
-                new KafkaProtobufDeserializer<>(PingMessage.Ping.parser()));
+        producer = companion.produceWithSerializers(new StringSerializer(), new KafkaProtobufSerializer<>());
+        consumer = companion
+                .consumeWithDeserializers(new StringDeserializer(), new KafkaProtobufDeserializer<>(PingMessage.Ping.parser()))
+                .withGroupId("test").withOffsetReset(OffsetResetStrategy.EARLIEST.toString()).withAutoCommit();
 
         registry.clear();
 
@@ -104,26 +100,21 @@ public class GlobalDLQProductionExceptionHandlerQuarkusTest {
     public void tearDown() {
         producer.close();
         consumer.close();
-        dlqConsumer.close();
     }
 
     @Test
     public void bigMessageShouldGoInDlqTopic() throws Exception {
-        consumer.subscribe(List.of(kStreamsProcessorConfig.output().topic().get()));
-        dlqConsumer.subscribe(List.of(GLOBALDLQ_TOPIC));
-
         String bigMessage = new LoremIpsum().getWords(100);
         PingMessage.Ping ping = PingMessage.Ping.newBuilder().setMessage(bigMessage).build();
 
-        producer.send(new ProducerRecord<>(inputTopic, 0, null, ping));
-        producer.send(new ProducerRecord<>(inputTopic, ping));
-        producer.send(new ProducerRecord<>(inputTopic, ping));
-        producer.flush();
+        producer.fromRecords(new ProducerRecord<>(inputTopic, 0, null, ping)).awaitCompletion(Duration.ofSeconds(1));
+        producer.fromRecords(new ProducerRecord<>(inputTopic, ping)).awaitCompletion(Duration.ofSeconds(1));
+        producer.fromRecords(new ProducerRecord<>(inputTopic, ping)).awaitCompletion(Duration.ofSeconds(1));
 
-        ConsumerRecords<String, PingMessage.Ping> dlqRecords = KafkaTestUtils.getRecords(dlqConsumer, Duration.ofSeconds(10),
-                3);
+        List<ConsumerRecord<String, PingMessage.Ping>> dlqRecords = consumer.fromTopics(GLOBALDLQ_TOPIC, 3)
+                .awaitCompletion(Duration.ofSeconds(10)).getRecords();
 
-        assertEquals(3, dlqRecords.count(), "We do not have 3 records big message in the DLQ");
+        assertThat(dlqRecords, hasSize(3));
 
         double globalDlqMessagesSent = getMetricAsFloat("\"kafkastreamsprocessor.global.dlq.sent\"");
         assertThat(globalDlqMessagesSent, closeTo(3.0d, 0.1d));

--- a/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/LogAndSendToDlqExceptionHandlerDelegateQuarkusTest.java
+++ b/impl/src/test/java/io/quarkiverse/kafkastreamsprocessor/impl/errors/LogAndSendToDlqExceptionHandlerDelegateQuarkusTest.java
@@ -34,20 +34,16 @@ import java.util.Set;
 import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
 
-import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.processor.api.ContextualProcessor;
 import org.apache.kafka.streams.processor.api.Record;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufDeserializer;
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufSerializer;
@@ -56,13 +52,20 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkiverse.kafkastreamsprocessor.api.Processor;
 import io.quarkiverse.kafkastreamsprocessor.sample.message.PingMessage;
 import io.quarkiverse.kafkastreamsprocessor.spi.properties.KStreamsProcessorConfig;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
 import io.restassured.http.ContentType;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder;
 
 @QuarkusTest
 @TestProfile(LogAndSendToDlqExceptionHandlerDelegateQuarkusTest.TestProfile.class)
+@QuarkusTestResource(KafkaCompanionResource.class)
 class LogAndSendToDlqExceptionHandlerDelegateQuarkusTest {
     private static final String DLQ_TOPIC = "dlq-topic";
 
@@ -72,20 +75,20 @@ class LogAndSendToDlqExceptionHandlerDelegateQuarkusTest {
     @Inject
     MeterRegistry registry;
 
-    @ConfigProperty(name = "kafka.bootstrap.servers")
-    String kafkaBootstrapServers;
+    @InjectKafkaCompanion
+    KafkaCompanion companion;
 
-    KafkaProducer<String, PingMessage.Ping> producer;
+    ProducerBuilder<String, PingMessage.Ping> producer;
 
-    KafkaConsumer<String, PingMessage.Ping> consumer;
+    ConsumerBuilder<String, PingMessage.Ping> consumer;
 
-    KafkaConsumer<byte[], byte[]> dlqConsumer;
+    ConsumerBuilder<byte[], byte[]> dlqConsumer;
 
     @BeforeEach
     public void setup() {
         registry.clear();
 
-        producer = new KafkaProducer<>(KafkaTestUtils.producerProps(kafkaBootstrapServers), new StringSerializer(),
+        producer = companion.produceWithSerializers(new StringSerializer(),
                 new KafkaProtobufSerializer<>() {
                     // Generate invalid protobuf messages to trigger a deserialization error
                     @Override
@@ -93,13 +96,8 @@ class LogAndSendToDlqExceptionHandlerDelegateQuarkusTest {
                         return "InvalidProtobufPayload".getBytes(StandardCharsets.UTF_8);
                     }
                 });
-
-        Map<String, Object> dlqConsumerProps = KafkaTestUtils.consumerProps(kafkaBootstrapServers, "dlq", "true");
-        dlqConsumer = new KafkaConsumer<>(dlqConsumerProps, new ByteArrayDeserializer(),
-                new ByteArrayDeserializer());
-
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(kafkaBootstrapServers, "test", "true");
-        consumer = new KafkaConsumer<>(consumerProps, new StringDeserializer(),
+        dlqConsumer = companion.consumeWithDeserializers(new ByteArrayDeserializer(), new ByteArrayDeserializer());
+        consumer = companion.consumeWithDeserializers(new StringDeserializer(),
                 new KafkaProtobufDeserializer<>(PingMessage.Ping.parser()));
     }
 
@@ -112,19 +110,21 @@ class LogAndSendToDlqExceptionHandlerDelegateQuarkusTest {
 
     @Test
     void deserializationErrorShouldGoInDlqTopic() throws Exception {
-        consumer.subscribe(List.of(kStreamsProcessorConfig.output().topic().get()));
-        dlqConsumer.subscribe(List.of(DLQ_TOPIC));
+        // use topic(s) in List.of(kStreamsProcessorConfig.output().topic().get()) with consumer.fromTopics at consumption time
+
+        // use topic(s) in List.of(DLQ_TOPIC) with consumer.fromTopics at consumption time
 
         PingMessage.Ping ping = PingMessage.Ping.newBuilder().setMessage("WillBeCorruptedBySerializer").build();
-        producer.send(
+        producer.fromRecords(
                 new ProducerRecord<String, PingMessage.Ping>(kStreamsProcessorConfig.input().topic().get(), 0,
                         null,
-                        ping));
-        producer.flush();
+                        ping))
+                .awaitCompletion(Duration.ofSeconds(1));
 
-        ConsumerRecords<byte[], byte[]> dlqRecords = KafkaTestUtils.getRecords(dlqConsumer, Duration.ofSeconds(10), 1);
+        List<ConsumerRecord<byte[], byte[]>> dlqRecords = dlqConsumer.fromTopics(DLQ_TOPIC, 1)
+                .awaitCompletion(Duration.ofSeconds(10)).getRecords();
 
-        assertEquals(1, dlqRecords.count(), "We do not have 1 corrupt protobuf message in the DLQ");
+        assertEquals(1, dlqRecords.size(), "We do not have 1 corrupt protobuf message in the DLQ");
 
         double globalDlqMessagesSent = getMetricAsFloat("\"kafkastreamsprocessor.global.dlq.sent\"");
         assertThat(globalDlqMessagesSent, closeTo(0.0d, 0.1d));

--- a/integration-tests/consumer/pom.xml
+++ b/integration-tests/consumer/pom.xml
@@ -110,10 +110,15 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.springframework.kafka</groupId>
-            <artifactId>spring-kafka-test</artifactId>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>smallrye-reactive-messaging-kafka-test-companion</artifactId>
             <scope>test</scope>
         </dependency>
+      <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-test-kafka-companion</artifactId>
+        <scope>test</scope>
+      </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>

--- a/integration-tests/consumer/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/consumer/ConsumerProcessorQuarkusTest.java
+++ b/integration-tests/consumer/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/consumer/ConsumerProcessorQuarkusTest.java
@@ -25,38 +25,36 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.is;
 
 import java.time.Duration;
-import java.util.Map;
 
-import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
-import io.quarkiverse.kafkastreamsprocessor.testframework.KafkaBootstrapServers;
-import io.quarkiverse.kafkastreamsprocessor.testframework.QuarkusIntegrationCompatibleKafkaDevServicesResource;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder;
 
 /**
  * Blackbox test that can run both in JVM and native modes (@Inject and @ConfigProperty not allowed)
  */
 @QuarkusTest
-@QuarkusTestResource(QuarkusIntegrationCompatibleKafkaDevServicesResource.class)
+@QuarkusTestResource(KafkaCompanionResource.class)
 public class ConsumerProcessorQuarkusTest {
-    @KafkaBootstrapServers
-    String kafkaBootstrapServers;
+    @InjectKafkaCompanion
+    KafkaCompanion companion;
 
     String senderTopic = "input-topic";
 
-    KafkaProducer<String, String> producer;
+    ProducerBuilder<String, String> producer;
 
     @BeforeEach
     public void setup() {
-        Map<String, Object> producerProps = KafkaTestUtils.producerProps(kafkaBootstrapServers);
-        producer = new KafkaProducer<>(producerProps, new StringSerializer(), new StringSerializer());
+        producer = companion.produceWithSerializers(new StringSerializer(), new StringSerializer());
     }
 
     @AfterEach
@@ -77,8 +75,8 @@ public class ConsumerProcessorQuarkusTest {
                 .statusCode(200)
                 .body(is("No events cached"));
 
-        producer.send(new ProducerRecord<>(senderTopic, "MyEventKey", "{ \"value\": \"Hello, World!\" }"));
-        producer.flush();
+        producer.fromRecords(new ProducerRecord<>(senderTopic, "MyEventKey", "{ \"value\": \"Hello, World!\" }"))
+                .awaitCompletion(Duration.ofSeconds(1));
 
         await().atMost(Duration.ofSeconds(10))
                 .until(() -> "Key: MyEventKey, Value: MyData[value=Hello, World!]\n".equals(

--- a/integration-tests/custom-serde/pom.xml
+++ b/integration-tests/custom-serde/pom.xml
@@ -128,8 +128,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.springframework.kafka</groupId>
-      <artifactId>spring-kafka-test</artifactId>
+      <groupId>io.smallrye.reactive</groupId>
+      <artifactId>smallrye-reactive-messaging-kafka-test-companion</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-test-kafka-companion</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/integration-tests/custom-serde/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/customserde/PingProcessorQuarkusTest.java
+++ b/integration-tests/custom-serde/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/customserde/PingProcessorQuarkusTest.java
@@ -24,51 +24,51 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.Map;
+import java.time.Duration;
 
 import jakarta.inject.Inject;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.awaitility.Durations;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder;
 
 @QuarkusTest
+@QuarkusTestResource(KafkaCompanionResource.class)
 public class PingProcessorQuarkusTest {
-    @ConfigProperty(name = "kafka.bootstrap.servers")
-    String kafkaBootstrapServers;
+    @InjectKafkaCompanion
+    KafkaCompanion companion;
 
     String senderTopic = "ping-events";
 
     String consumerTopic = "pong-events";
 
-    KafkaProducer<String, CustomType> producer;
+    ProducerBuilder<String, CustomType> producer;
 
-    KafkaConsumer<String, CustomType> consumer;
+    ConsumerBuilder<String, CustomType> consumer;
 
     @Inject
     CustomTypeSerde customTypeSerde;
 
     @BeforeEach
     public void setup() throws Exception {
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(kafkaBootstrapServers, "test", "true");
-        consumer = new KafkaConsumer<>(consumerProps, new StringDeserializer(), customTypeSerde.deserializer());
-        consumer.subscribe(List.of(consumerTopic));
-
-        Map<String, Object> producerProps = KafkaTestUtils.producerProps(kafkaBootstrapServers);
-        producer = new KafkaProducer<>(producerProps, new StringSerializer(), customTypeSerde.serializer());
+        consumer = companion.consumeWithDeserializers(new StringDeserializer(), customTypeSerde.deserializer())
+                .withGroupId("test").withOffsetReset(OffsetResetStrategy.EARLIEST.toString()).withAutoCommit();
+        producer = companion.produceWithSerializers(new StringSerializer(), customTypeSerde.serializer());
     }
 
     @AfterEach
@@ -79,19 +79,18 @@ public class PingProcessorQuarkusTest {
 
     @Test
     public void testCount() {
-        producer.send(new ProducerRecord<>(senderTopic, "1", new CustomType(1)));
-        producer.flush();
-        ConsumerRecord<String, CustomType> record = KafkaTestUtils.getSingleRecord(consumer, consumerTopic,
-                Durations.FIVE_SECONDS);
+        producer.fromRecords(new ProducerRecord<>(senderTopic, "1", new CustomType(1))).awaitCompletion(Duration.ofSeconds(1));
+        ConsumerRecord<String, CustomType> record = consumer.fromTopics(consumerTopic, 1)
+                .awaitCompletion(Durations.FIVE_SECONDS).getFirstRecord();
         assertThat(((CustomType) record.value()).getValue(), equalTo(1));
     }
 
     @Test
     public void testHeaderError() {
-        producer.send(new ProducerRecord<>(senderTopic, 0, "1", new CustomType(1),
-                new RecordHeaders().add("custom-header", "error".getBytes(StandardCharsets.UTF_8))));
-        producer.flush();
-        assertThrows(IllegalStateException.class,
-                () -> KafkaTestUtils.getSingleRecord(consumer, consumerTopic, Durations.FIVE_SECONDS));
+        producer.fromRecords(new ProducerRecord<>(senderTopic, 0, "1", new CustomType(1),
+                new RecordHeaders().add("custom-header", "error".getBytes(StandardCharsets.UTF_8))))
+                .awaitCompletion(Duration.ofSeconds(1));
+        assertThrows(AssertionError.class,
+                () -> consumer.fromTopics(consumerTopic, 1).awaitCompletion(Durations.FIVE_SECONDS).getFirstRecord());
     }
 }

--- a/integration-tests/edition-2024-generated/pom.xml
+++ b/integration-tests/edition-2024-generated/pom.xml
@@ -120,8 +120,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.springframework.kafka</groupId>
-      <artifactId>spring-kafka-test</artifactId>
+      <groupId>io.smallrye.reactive</groupId>
+      <artifactId>smallrye-reactive-messaging-kafka-test-companion</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-test-kafka-companion</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/integration-tests/edition-2024-generated/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/simple/PingProcessorQuarkusTest.java
+++ b/integration-tests/edition-2024-generated/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/simple/PingProcessorQuarkusTest.java
@@ -21,12 +21,10 @@ package io.quarkiverse.kafkastreamsprocessor.sample.simple;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.List;
-import java.util.Map;
+import java.time.Duration;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -34,43 +32,41 @@ import org.awaitility.Durations;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufDeserializer;
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufSerializer;
 
 import io.quarkiverse.kafkastreamsprocessor.sample.message.Ping;
-import io.quarkiverse.kafkastreamsprocessor.testframework.KafkaBootstrapServers;
-import io.quarkiverse.kafkastreamsprocessor.testframework.QuarkusIntegrationCompatibleKafkaDevServicesResource;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder;
 
 /**
  * Blackbox test that can run both in JVM and native modes (@Inject and @ConfigProperty not allowed)
  */
 @QuarkusTest
-@QuarkusTestResource(QuarkusIntegrationCompatibleKafkaDevServicesResource.class)
+@QuarkusTestResource(KafkaCompanionResource.class)
 public class PingProcessorQuarkusTest {
-    @KafkaBootstrapServers
-    String kafkaBootstrapServers;
+    @InjectKafkaCompanion
+    KafkaCompanion companion;
 
     String senderTopic = "ping-events";
 
     String consumerTopic = "pong-events";
 
-    KafkaProducer<String, Ping> producer;
+    ProducerBuilder<String, Ping> producer;
 
-    KafkaConsumer<String, Ping> consumer;
+    ConsumerBuilder<String, Ping> consumer;
 
     @BeforeEach
     public void setup() {
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(kafkaBootstrapServers, "test", "true");
-        consumer = new KafkaConsumer<>(consumerProps, new StringDeserializer(), new KafkaProtobufDeserializer<>(Ping.parser()));
-        consumer.subscribe(List.of(consumerTopic));
-
-        Map<String, Object> producerProps = KafkaTestUtils.producerProps(kafkaBootstrapServers);
-        producer = new KafkaProducer<>(producerProps, new StringSerializer(),
-                new KafkaProtobufSerializer<>());
+        consumer = companion.consumeWithDeserializers(new StringDeserializer(), new KafkaProtobufDeserializer<>(Ping.parser()))
+                .withGroupId("test").withOffsetReset(OffsetResetStrategy.EARLIEST.toString()).withAutoCommit();
+        producer = companion.produceWithSerializers(new StringSerializer(), new KafkaProtobufSerializer<>());
     }
 
     @AfterEach
@@ -81,9 +77,10 @@ public class PingProcessorQuarkusTest {
 
     @Test
     public void testCount() {
-        producer.send(new ProducerRecord<>(senderTopic, Ping.newBuilder().setMessage("world").build()));
-        producer.flush();
-        ConsumerRecord<String, Ping> record = KafkaTestUtils.getSingleRecord(consumer, consumerTopic, Durations.FIVE_SECONDS);
+        producer.fromRecords(new ProducerRecord<>(senderTopic, Ping.newBuilder().setMessage("world").build()))
+                .awaitCompletion(Duration.ofSeconds(1));
+        ConsumerRecord<String, Ping> record = consumer.fromTopics(consumerTopic, 1).awaitCompletion(Durations.FIVE_SECONDS)
+                .getFirstRecord();
         assertEquals("5", record.value().getMessage());
     }
 

--- a/integration-tests/json-pojo/pom.xml
+++ b/integration-tests/json-pojo/pom.xml
@@ -133,8 +133,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.springframework.kafka</groupId>
-      <artifactId>spring-kafka-test</artifactId>
+      <groupId>io.smallrye.reactive</groupId>
+      <artifactId>smallrye-reactive-messaging-kafka-test-companion</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-test-kafka-companion</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/integration-tests/json-pojo/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/jsonpojo/PojoProcessorQuarkusTest.java
+++ b/integration-tests/json-pojo/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/jsonpojo/PojoProcessorQuarkusTest.java
@@ -23,54 +23,53 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import java.util.List;
-import java.util.Map;
+import java.time.Duration;
 
 import jakarta.inject.Inject;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.awaitility.Durations;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkiverse.kafkastreamsprocessor.spi.properties.KStreamsProcessorConfig;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder;
 
 @QuarkusTest
+@QuarkusTestResource(KafkaCompanionResource.class)
 public class PojoProcessorQuarkusTest {
-
-    @ConfigProperty(name = "kafka.bootstrap.servers")
-    String kafkaBootstrapServers;
+    @InjectKafkaCompanion
+    KafkaCompanion companion;
 
     @Inject
     KStreamsProcessorConfig kStreamsProcessorConfig;
 
-    KafkaProducer<String, String> producer;
+    ProducerBuilder<String, String> producer;
 
-    KafkaConsumer<String, String> consumer;
+    ConsumerBuilder<String, String> consumer;
 
     @Inject
     ObjectMapper objectMapper;
 
     @BeforeEach
     public void setup() {
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(kafkaBootstrapServers, "test", "true");
-        consumer = new KafkaConsumer<>(consumerProps, new StringDeserializer(),
-                new StringDeserializer());
-        consumer.subscribe(List.of(kStreamsProcessorConfig.output().topic().get()));
-        Map<String, Object> producerProps = KafkaTestUtils.producerProps(kafkaBootstrapServers);
-        producer = new KafkaProducer<>(producerProps, new StringSerializer(), new StringSerializer());
+        consumer = companion.consumeWithDeserializers(new StringDeserializer(), new StringDeserializer())
+                .withGroupId("test").withOffsetReset(OffsetResetStrategy.EARLIEST.toString()).withAutoCommit();
+        producer = companion.produceWithSerializers(new StringSerializer(), new StringSerializer());
     }
 
     @AfterEach
@@ -84,11 +83,12 @@ public class PojoProcessorQuarkusTest {
         SamplePojo pojo = new SamplePojo("hello", 1234, true);
         String json = objectMapper.writeValueAsString(pojo);
 
-        producer.send(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(), json));
-        producer.flush();
+        producer.fromRecords(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(), json))
+                .awaitCompletion(Duration.ofSeconds(1));
 
-        ConsumerRecord<String, String> record = KafkaTestUtils.getSingleRecord(consumer,
-                kStreamsProcessorConfig.output().topic().get(), Durations.FIVE_SECONDS);
+        ConsumerRecord<String, String> record = consumer.fromTopics(kStreamsProcessorConfig.output().topic().get(), 1)
+                .awaitCompletion(Durations.FIVE_SECONDS)
+                .getFirstRecord();
         SamplePojo expected = new SamplePojo("olleh", 1271, false);
 
         assertThat(objectMapper.readValue(record.value(), SamplePojo.class), is(equalTo(expected)));

--- a/integration-tests/kafka-to-rest/pom.xml
+++ b/integration-tests/kafka-to-rest/pom.xml
@@ -165,8 +165,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.springframework.kafka</groupId>
-      <artifactId>spring-kafka-test</artifactId>
+      <groupId>io.smallrye.reactive</groupId>
+      <artifactId>smallrye-reactive-messaging-kafka-test-companion</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-test-kafka-companion</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/integration-tests/kafka-to-rest/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/kafkatorest/PingClientProcessorQuarkusTest.java
+++ b/integration-tests/kafka-to-rest/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/kafkatorest/PingClientProcessorQuarkusTest.java
@@ -23,61 +23,63 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
-import java.util.List;
-import java.util.Map;
+import java.time.Duration;
 
 import jakarta.inject.Inject;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.awaitility.Durations;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockserver.integration.ClientAndServer;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufDeserializer;
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufSerializer;
 
 import io.quarkiverse.kafkastreamsprocessor.sample.message.PingMessage.Ping;
 import io.quarkiverse.kafkastreamsprocessor.spi.properties.KStreamsProcessorConfig;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder;
 
 @QuarkusTest
+@QuarkusTestResource(KafkaCompanionResource.class)
 class PingClientProcessorQuarkusTest {
     private ClientAndServer httpServer;
 
     @Inject
     KStreamsProcessorConfig kStreamsProcessorConfig;
 
-    @ConfigProperty(name = "kafka.bootstrap.servers")
-    String kafkaBootstrapServers;
+    @InjectKafkaCompanion
+    KafkaCompanion companion;
 
-    KafkaProducer<String, Ping> producer;
+    ProducerBuilder<String, Ping> producer;
 
-    KafkaConsumer<String, Ping> consumer;
+    ConsumerBuilder<String, Ping> consumer;
 
     @BeforeEach
     public void setup() {
-        producer = new KafkaProducer<>(KafkaTestUtils.producerProps(kafkaBootstrapServers), new StringSerializer(),
-                new KafkaProtobufSerializer<>());
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(kafkaBootstrapServers, "test", "true");
-        consumer = new KafkaConsumer<>(consumerProps, new StringDeserializer(),
-                new KafkaProtobufDeserializer<>(Ping.parser()));
-        consumer.subscribe(List.of(kStreamsProcessorConfig.output().topic().get()));
+        producer = companion.produceWithSerializers(new StringSerializer(), new KafkaProtobufSerializer<>());
+        consumer = companion.consumeWithDeserializers(new StringDeserializer(), new KafkaProtobufDeserializer<>(Ping.parser()))
+                .withGroupId("test").withOffsetReset(OffsetResetStrategy.EARLIEST.toString()).withAutoCommit();
+        // use topic(s) in List.of(kStreamsProcessorConfig.output().topic().get()) with consumer.fromTopics at consumption time
+
         httpServer = ClientAndServer.startClientAndServer(9095);
     }
 
     @AfterEach
     public void tearDown() {
-        producer.close(Durations.ONE_SECOND);
-        consumer.close(Durations.ONE_SECOND);
+        producer.close();
+        consumer.close();
         httpServer.stop();
     }
 
@@ -87,14 +89,11 @@ class PingClientProcessorQuarkusTest {
                 .when(request().withPath("/ping"))
                 .respond(response("PONG"));
 
-        producer.send(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(),
-                Ping.newBuilder().setMessage("hello").build()));
-        producer.flush();
+        producer.fromRecords(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(),
+                Ping.newBuilder().setMessage("hello").build())).awaitCompletion(Duration.ofSeconds(1));
 
-        ConsumerRecord<String, Ping> singleRecord = KafkaTestUtils.getSingleRecord(consumer,
-                kStreamsProcessorConfig.output().topic().get(),
-                Durations.TEN_SECONDS);
-        consumer.commitSync();
+        ConsumerRecord<String, Ping> singleRecord = consumer.fromTopics(kStreamsProcessorConfig.output().topic().get(), 1)
+                .awaitCompletion(Durations.TEN_SECONDS).getFirstRecord();
 
         assertEquals("PONG of hello", singleRecord.value().getMessage());
     }

--- a/integration-tests/kafka-to-rest/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/kafkatorest/PingClientProcessorQuarkusWithRetryTest.java
+++ b/integration-tests/kafka-to-rest/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/kafkatorest/PingClientProcessorQuarkusWithRetryTest.java
@@ -25,24 +25,20 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
-import java.util.Map;
+import java.time.Duration;
 
 import jakarta.inject.Inject;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.awaitility.Durations;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufDeserializer;
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufSerializer;
@@ -51,20 +47,27 @@ import io.quarkiverse.kafkastreamsprocessor.api.exception.RetryableException;
 import io.quarkiverse.kafkastreamsprocessor.sample.message.PingMessage.Ping;
 import io.quarkiverse.kafkastreamsprocessor.spi.properties.KStreamsProcessorConfig;
 import io.quarkus.test.InjectMock;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder;
 
 @QuarkusTest
+@QuarkusTestResource(KafkaCompanionResource.class)
 class PingClientProcessorQuarkusWithRetryTest {
 
     @Inject
     KStreamsProcessorConfig kStreamsProcessorConfig;
 
-    @ConfigProperty(name = "kafka.bootstrap.servers")
-    String kafkaBootstrapServers;
+    @InjectKafkaCompanion
+    KafkaCompanion companion;
 
-    KafkaProducer<String, Ping> producer;
+    ProducerBuilder<String, Ping> producer;
 
-    KafkaConsumer<String, Ping> consumer;
+    ConsumerBuilder<String, Ping> consumer;
 
     // Building on the features provided by QuarkusMock, Quarkus also allows users to effortlessly take advantage of
     // Mockito for mocking the beans supported by QuarkusMock. This functionality is available via the
@@ -76,18 +79,15 @@ class PingClientProcessorQuarkusWithRetryTest {
 
     @BeforeEach
     public void setup() {
-        producer = new KafkaProducer<>(KafkaTestUtils.producerProps(kafkaBootstrapServers), new StringSerializer(),
-                new KafkaProtobufSerializer<>());
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(kafkaBootstrapServers, "test", "true");
-        consumer = new KafkaConsumer<>(consumerProps, new StringDeserializer(),
-                new KafkaProtobufDeserializer<>(Ping.parser()));
-        consumer.subscribe(List.of(kStreamsProcessorConfig.output().topic().get()));
+        producer = companion.produceWithSerializers(new StringSerializer(), new KafkaProtobufSerializer<>());
+        consumer = companion.consumeWithDeserializers(new StringDeserializer(), new KafkaProtobufDeserializer<>(Ping.parser()))
+                .withGroupId("test").withOffsetReset(OffsetResetStrategy.EARLIEST.toString()).withAutoCommit();
     }
 
     @AfterEach
     public void tearDown() {
-        producer.close(Durations.ONE_SECOND);
-        consumer.close(Durations.ONE_SECOND);
+        producer.close();
+        consumer.close();
     }
 
     @Test
@@ -99,14 +99,11 @@ class PingClientProcessorQuarkusWithRetryTest {
                 .thenThrow(mock(RetryableException.class))
                 .thenReturn("PONG");
 
-        producer.send(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(),
-                Ping.newBuilder().setMessage("hello").build()));
-        producer.flush();
+        producer.fromRecords(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(),
+                Ping.newBuilder().setMessage("hello").build())).awaitCompletion(Duration.ofSeconds(1));
 
-        ConsumerRecord<String, Ping> singleRecord = KafkaTestUtils.getSingleRecord(consumer,
-                kStreamsProcessorConfig.output().topic().get(),
-                Durations.TEN_SECONDS);
-        consumer.commitSync();
+        ConsumerRecord<String, Ping> singleRecord = consumer.fromTopics(kStreamsProcessorConfig.output().topic().get(), 1)
+                .awaitCompletion(Durations.TEN_SECONDS).getFirstRecord();
 
         assertEquals("PONG of hello", singleRecord.value().getMessage());
         verify(client, times(4)).ping(); // 3 retry + 1

--- a/integration-tests/kafka-to-rest/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/kafkatorest/PingClientProcessorQuarkusWithoutRetryCatchTest.java
+++ b/integration-tests/kafka-to-rest/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/kafkatorest/PingClientProcessorQuarkusWithoutRetryCatchTest.java
@@ -20,26 +20,21 @@
 package io.quarkiverse.kafkastreamsprocessor.sample.kafkatorest;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
-import java.util.Map;
+import java.time.Duration;
 
 import jakarta.inject.Inject;
 
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.awaitility.Durations;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufDeserializer;
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufSerializer;
@@ -47,20 +42,27 @@ import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufSerializer;
 import io.quarkiverse.kafkastreamsprocessor.sample.message.PingMessage.Ping;
 import io.quarkiverse.kafkastreamsprocessor.spi.properties.KStreamsProcessorConfig;
 import io.quarkus.test.InjectMock;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder;
 
 @QuarkusTest
+@QuarkusTestResource(KafkaCompanionResource.class)
 class PingClientProcessorQuarkusWithoutRetryCatchTest {
 
     @Inject
     KStreamsProcessorConfig kStreamsProcessorConfig;
 
-    @ConfigProperty(name = "kafka.bootstrap.servers")
-    String kafkaBootstrapServers;
+    @InjectKafkaCompanion
+    KafkaCompanion companion;
 
-    KafkaProducer<String, Ping> producer;
+    ProducerBuilder<String, Ping> producer;
 
-    KafkaConsumer<String, Ping> consumer;
+    ConsumerBuilder<String, Ping> consumer;
 
     // Building on the features provided by QuarkusMock, Quarkus also allows users to effortlessly take advantage of
     // Mockito for mocking the beans supported by QuarkusMock. This functionality is available via the
@@ -72,33 +74,29 @@ class PingClientProcessorQuarkusWithoutRetryCatchTest {
 
     @BeforeEach
     public void setup() {
-        producer = new KafkaProducer<>(KafkaTestUtils.producerProps(kafkaBootstrapServers), new StringSerializer(),
-                new KafkaProtobufSerializer<>());
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(kafkaBootstrapServers, "test", "true");
-        consumer = new KafkaConsumer<>(consumerProps, new StringDeserializer(),
-                new KafkaProtobufDeserializer<>(Ping.parser()));
-        consumer.subscribe(List.of(kStreamsProcessorConfig.output().topic().get()));
+        producer = companion.produceWithSerializers(new StringSerializer(), new KafkaProtobufSerializer<>());
+        consumer = companion.consumeWithDeserializers(new StringDeserializer(), new KafkaProtobufDeserializer<>(Ping.parser()))
+                .withGroupId("test").withOffsetReset(OffsetResetStrategy.EARLIEST.toString()).withAutoCommit();
     }
 
     @AfterEach
     public void tearDown() {
-        producer.close(Durations.ONE_SECOND);
-        consumer.close(Durations.ONE_SECOND);
+        producer.close();
+        consumer.close();
     }
 
     @Test
     void singleMessageWithoutRetry() {
         // throw Exception
         when(client.ping())
-                .thenThrow(mock(RuntimeException.class));
+                .thenThrow(new RuntimeException());
 
-        producer.send(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(),
-                Ping.newBuilder().setMessage("hello").build()));
-        producer.flush();
+        producer.fromRecords(new ProducerRecord<>(kStreamsProcessorConfig.input().topic().get(),
+                Ping.newBuilder().setMessage("hello").build())).awaitCompletion(Duration.ofSeconds(1));
 
-        assertThrows(IllegalStateException.class, () -> {
-            KafkaTestUtils.getSingleRecord(consumer, kStreamsProcessorConfig.output().topic().get(),
-                    Durations.TEN_SECONDS);
+        assertThrows(AssertionError.class, () -> {
+            consumer.fromTopics(kStreamsProcessorConfig.output().topic().get(), 1)
+                    .awaitCompletion(Durations.TEN_SECONDS).getFirstRecord();
         });
     }
 }

--- a/integration-tests/multioutput/pom.xml
+++ b/integration-tests/multioutput/pom.xml
@@ -129,8 +129,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.springframework.kafka</groupId>
-      <artifactId>spring-kafka-test</artifactId>
+      <groupId>io.smallrye.reactive</groupId>
+      <artifactId>smallrye-reactive-messaging-kafka-test-companion</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-test-kafka-companion</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/integration-tests/multioutput/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/multioutput/PingProcessorQuarkusTest.java
+++ b/integration-tests/multioutput/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/multioutput/PingProcessorQuarkusTest.java
@@ -21,12 +21,10 @@ package io.quarkiverse.kafkastreamsprocessor.sample.multioutput;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.List;
-import java.util.Map;
+import java.time.Duration;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -35,60 +33,60 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufDeserializer;
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufSerializer;
 
 import io.quarkiverse.kafkastreamsprocessor.sample.message.PingMessage.Ping;
-import io.quarkiverse.kafkastreamsprocessor.testframework.KafkaBootstrapServers;
-import io.quarkiverse.kafkastreamsprocessor.testframework.QuarkusIntegrationCompatibleKafkaDevServicesResource;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder;
 
 /**
  * Blackbox test that can run both in JVM and native modes (@Inject and @ConfigProperty not allowed)
  */
 @QuarkusTest
-@QuarkusTestResource(QuarkusIntegrationCompatibleKafkaDevServicesResource.class)
+@QuarkusTestResource(KafkaCompanionResource.class)
 public class PingProcessorQuarkusTest {
-    @KafkaBootstrapServers
-    String kafkaBootstrapServers;
+    @InjectKafkaCompanion
+    KafkaCompanion companion;
 
     String senderTopic = "ping-events";
 
     String consumerPongTopic = "pong-events";
     String consumerPangTopic = "pang-events";
 
-    KafkaProducer<String, Ping> producer;
+    ProducerBuilder<String, Ping> producer;
 
-    KafkaConsumer<String, Ping> consumer;
+    ConsumerBuilder<String, Ping> consumer;
 
     @BeforeEach
     public void setup() {
-        producer = new KafkaProducer(KafkaTestUtils.producerProps(kafkaBootstrapServers), new StringSerializer(),
+        producer = companion.produceWithSerializers(new StringSerializer(),
                 new KafkaProtobufSerializer<>());
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(kafkaBootstrapServers, "test", "true");
-        consumer = new KafkaConsumer(consumerProps, new StringDeserializer(),
-                new KafkaProtobufDeserializer<>(Ping.parser()));
-        consumer.subscribe(List.of(consumerPongTopic, consumerPangTopic));
+        consumer = companion.consumeWithDeserializers(new StringDeserializer(),
+                new KafkaProtobufDeserializer<>(Ping.parser())).withGroupId("test")
+                .withOffsetReset(OffsetResetStrategy.EARLIEST.toString()).withAutoCommit();
     }
 
     @AfterEach
     public void tearDown() {
-        producer.close(Durations.ONE_SECOND);
-        consumer.close(Durations.ONE_SECOND);
+        producer.close();
+        consumer.close();
     }
 
     @Test
     public void testNominalCase() {
         Ping ping = Ping.newBuilder().setMessage("world").build();
 
-        producer.send(new ProducerRecord<>(senderTopic, ping));
-        producer.flush();
+        producer.fromRecords(new ProducerRecord<>(senderTopic, ping)).awaitCompletion(Duration.ofSeconds(1));
 
-        ConsumerRecord<String, Ping> record = KafkaTestUtils.getSingleRecord(consumer, consumerPongTopic,
-                Durations.TEN_SECONDS);
+        ConsumerRecord<String, Ping> record = consumer.fromTopics(consumerPongTopic, 1).awaitCompletion(Durations.TEN_SECONDS)
+                .getFirstRecord();
         assertEquals("5", record.value().getMessage());
     }
 
@@ -96,11 +94,10 @@ public class PingProcessorQuarkusTest {
     public void testFunctionalError() {
         Ping ping = Ping.newBuilder().setMessage("error").build();
 
-        producer.send(new ProducerRecord<>(senderTopic, ping));
-        producer.flush();
+        producer.fromRecords(new ProducerRecord<>(senderTopic, ping)).awaitCompletion(Duration.ofSeconds(1));
 
-        ConsumerRecord<String, Ping> record = KafkaTestUtils.getSingleRecord(consumer, consumerPangTopic,
-                Durations.TEN_SECONDS);
+        ConsumerRecord<String, Ping> record = consumer.fromTopics(consumerPangTopic, 1).awaitCompletion(Durations.TEN_SECONDS)
+                .getFirstRecord();
         assertEquals("PANG!", record.value().getMessage());
     }
 }

--- a/integration-tests/proto-3-generated/pom.xml
+++ b/integration-tests/proto-3-generated/pom.xml
@@ -120,8 +120,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.springframework.kafka</groupId>
-      <artifactId>spring-kafka-test</artifactId>
+      <groupId>io.smallrye.reactive</groupId>
+      <artifactId>smallrye-reactive-messaging-kafka-test-companion</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-test-kafka-companion</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/integration-tests/proto-3-generated/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/simple/PingProcessorQuarkusTest.java
+++ b/integration-tests/proto-3-generated/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/simple/PingProcessorQuarkusTest.java
@@ -21,12 +21,10 @@ package io.quarkiverse.kafkastreamsprocessor.sample.simple;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.List;
-import java.util.Map;
+import java.time.Duration;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -34,43 +32,41 @@ import org.awaitility.Durations;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufDeserializer;
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufSerializer;
 
 import io.quarkiverse.kafkastreamsprocessor.sample.message.PingMessage.Ping;
-import io.quarkiverse.kafkastreamsprocessor.testframework.KafkaBootstrapServers;
-import io.quarkiverse.kafkastreamsprocessor.testframework.QuarkusIntegrationCompatibleKafkaDevServicesResource;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder;
 
 /**
  * Blackbox test that can run both in JVM and native modes (@Inject and @ConfigProperty not allowed)
  */
 @QuarkusTest
-@QuarkusTestResource(QuarkusIntegrationCompatibleKafkaDevServicesResource.class)
+@QuarkusTestResource(KafkaCompanionResource.class)
 public class PingProcessorQuarkusTest {
-    @KafkaBootstrapServers
-    String kafkaBootstrapServers;
+    @InjectKafkaCompanion
+    KafkaCompanion companion;
 
     String senderTopic = "ping-events";
 
     String consumerTopic = "pong-events";
 
-    KafkaProducer<String, Ping> producer;
+    ProducerBuilder<String, Ping> producer;
 
-    KafkaConsumer<String, Ping> consumer;
+    ConsumerBuilder<String, Ping> consumer;
 
     @BeforeEach
     public void setup() {
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(kafkaBootstrapServers, "test", "true");
-        consumer = new KafkaConsumer<>(consumerProps, new StringDeserializer(), new KafkaProtobufDeserializer<>(Ping.parser()));
-        consumer.subscribe(List.of(consumerTopic));
-
-        Map<String, Object> producerProps = KafkaTestUtils.producerProps(kafkaBootstrapServers);
-        producer = new KafkaProducer<>(producerProps, new StringSerializer(),
-                new KafkaProtobufSerializer<>());
+        consumer = companion.consumeWithDeserializers(new StringDeserializer(), new KafkaProtobufDeserializer<>(Ping.parser()))
+                .withGroupId("test").withOffsetReset(OffsetResetStrategy.EARLIEST.toString()).withAutoCommit();
+        producer = companion.produceWithSerializers(new StringSerializer(), new KafkaProtobufSerializer<>());
     }
 
     @AfterEach
@@ -81,9 +77,10 @@ public class PingProcessorQuarkusTest {
 
     @Test
     public void testCount() {
-        producer.send(new ProducerRecord<>(senderTopic, Ping.newBuilder().setMessage("world").build()));
-        producer.flush();
-        ConsumerRecord<String, Ping> record = KafkaTestUtils.getSingleRecord(consumer, consumerTopic, Durations.FIVE_SECONDS);
+        producer.fromRecords(new ProducerRecord<>(senderTopic, Ping.newBuilder().setMessage("world").build()))
+                .awaitCompletion(Duration.ofSeconds(1));
+        ConsumerRecord<String, Ping> record = consumer.fromTopics(consumerTopic, 1).awaitCompletion(Durations.FIVE_SECONDS)
+                .getFirstRecord();
         assertEquals("5", record.value().getMessage());
     }
 

--- a/integration-tests/simple/pom.xml
+++ b/integration-tests/simple/pom.xml
@@ -120,8 +120,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.springframework.kafka</groupId>
-      <artifactId>spring-kafka-test</artifactId>
+      <groupId>io.smallrye.reactive</groupId>
+      <artifactId>smallrye-reactive-messaging-kafka-test-companion</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-test-kafka-companion</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/integration-tests/simple/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/simple/ParallelPingProcessorQuarkusTest.java
+++ b/integration-tests/simple/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/simple/ParallelPingProcessorQuarkusTest.java
@@ -19,7 +19,8 @@
  */
 package io.quarkiverse.kafkastreamsprocessor.sample.simple;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.nio.charset.StandardCharsets;
@@ -29,9 +30,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -39,43 +39,45 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufDeserializer;
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufSerializer;
 
 import io.quarkiverse.kafkastreamsprocessor.sample.message.PingMessage.Ping;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder;
 
 /**
  * Blackbox test that can run both in JVM and native modes (@Inject and @ConfigProperty not allowed)
  */
 @QuarkusTest
 @TestProfile(ParallelPingProcessorQuarkusTest.ParallelPingProcessorQuarkusTestProfile.class)
+@QuarkusTestResource(KafkaCompanionResource.class)
 public class ParallelPingProcessorQuarkusTest {
     public static final String W3C_TRACE_ID = "traceparent";
-    @ConfigProperty(name = "kafka.bootstrap.servers")
-    String kafkaBootstrapServers;
+    @InjectKafkaCompanion
+    KafkaCompanion companion;
 
     String senderTopic = "ping-events";
 
     String consumerTopic = "pong-events";
 
-    KafkaProducer<String, Ping> producer;
+    ProducerBuilder<String, Ping> producer;
 
-    KafkaConsumer<String, Ping> consumer;
+    ConsumerBuilder<String, Ping> consumer;
 
     @BeforeEach
     public void setup() {
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(kafkaBootstrapServers, "test", "true");
-        consumer = new KafkaConsumer<>(consumerProps, new StringDeserializer(), new KafkaProtobufDeserializer<>(Ping.parser()));
-        consumer.subscribe(List.of(consumerTopic));
-
-        Map<String, Object> producerProps = KafkaTestUtils.producerProps(kafkaBootstrapServers);
-        producer = new KafkaProducer<>(producerProps, new StringSerializer(),
-                new KafkaProtobufSerializer<>());
+        consumer = companion.consumeWithDeserializers(new StringDeserializer(), new KafkaProtobufDeserializer<>(Ping.parser()))
+                .withGroupId("test").withOffsetReset(OffsetResetStrategy.EARLIEST.toString()).withAutoCommit();
+        producer = companion.produceWithSerializers(new StringSerializer(), new KafkaProtobufSerializer<>());
     }
 
     @AfterEach
@@ -87,13 +89,15 @@ public class ParallelPingProcessorQuarkusTest {
     @Test
     public void multiPartitions() {
         // Send one message to each partition, they will be served each by one processor thread
-        producer.send(new ProducerRecord<>(senderTopic, 0, null, Ping.newBuilder().setMessage("blabla").build()));
-        producer.send(new ProducerRecord<>(senderTopic, 1, null, Ping.newBuilder().setMessage("blabla").build()));
-        producer.flush();
+        producer.fromRecords(new ProducerRecord<>(senderTopic, 0, null, Ping.newBuilder().setMessage("blabla").build()))
+                .awaitCompletion(Duration.ofSeconds(1));
+        producer.fromRecords(new ProducerRecord<>(senderTopic, 1, null, Ping.newBuilder().setMessage("blabla").build()))
+                .awaitCompletion(Duration.ofSeconds(1));
 
-        ConsumerRecords<String, Ping> records = KafkaTestUtils.getRecords(consumer, Duration.ofSeconds(10), 2);
+        List<ConsumerRecord<String, Ping>> records = consumer.fromTopics(consumerTopic, 2)
+                .awaitCompletion(Duration.ofSeconds(10)).getRecords();
 
-        assertEquals(2, records.count());
+        assertThat(records, hasSize(2));
         List<String> traceHeaderValues = StreamSupport.stream(records.spliterator(), false)
                 .map(record -> new String(record.headers().lastHeader(W3C_TRACE_ID).value(), StandardCharsets.UTF_8))
                 .collect(Collectors.toList());

--- a/integration-tests/simple/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/simple/PingProcessorQuarkusTest.java
+++ b/integration-tests/simple/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/simple/PingProcessorQuarkusTest.java
@@ -22,12 +22,10 @@ package io.quarkiverse.kafkastreamsprocessor.sample.simple;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.Map;
+import java.time.Duration;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -35,43 +33,41 @@ import org.awaitility.Durations;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufDeserializer;
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufSerializer;
 
 import io.quarkiverse.kafkastreamsprocessor.sample.message.PingMessage.Ping;
-import io.quarkiverse.kafkastreamsprocessor.testframework.KafkaBootstrapServers;
-import io.quarkiverse.kafkastreamsprocessor.testframework.QuarkusIntegrationCompatibleKafkaDevServicesResource;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder;
 
 /**
  * Blackbox test that can run both in JVM and native modes (@Inject and @ConfigProperty not allowed)
  */
 @QuarkusTest
-@QuarkusTestResource(QuarkusIntegrationCompatibleKafkaDevServicesResource.class)
+@QuarkusTestResource(KafkaCompanionResource.class)
 public class PingProcessorQuarkusTest {
-    @KafkaBootstrapServers
-    String kafkaBootstrapServers;
+    @InjectKafkaCompanion
+    KafkaCompanion companion;
 
     String senderTopic = "ping-events";
 
     String consumerTopic = "pong-events";
 
-    KafkaProducer<String, Ping> producer;
+    ProducerBuilder<String, Ping> producer;
 
-    KafkaConsumer<String, Ping> consumer;
+    ConsumerBuilder<String, Ping> consumer;
 
     @BeforeEach
     public void setup() {
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(kafkaBootstrapServers, "test", "true");
-        consumer = new KafkaConsumer<>(consumerProps, new StringDeserializer(), new KafkaProtobufDeserializer<>(Ping.parser()));
-        consumer.subscribe(List.of(consumerTopic));
-
-        Map<String, Object> producerProps = KafkaTestUtils.producerProps(kafkaBootstrapServers);
-        producer = new KafkaProducer<>(producerProps, new StringSerializer(),
-                new KafkaProtobufSerializer<>());
+        consumer = companion.consumeWithDeserializers(new StringDeserializer(), new KafkaProtobufDeserializer<>(Ping.parser()))
+                .withGroupId("test").withOffsetReset(OffsetResetStrategy.EARLIEST.toString()).withAutoCommit();
+        producer = companion.produceWithSerializers(new StringSerializer(), new KafkaProtobufSerializer<>());
     }
 
     @AfterEach
@@ -82,26 +78,29 @@ public class PingProcessorQuarkusTest {
 
     @Test
     public void testCount() {
-        producer.send(new ProducerRecord<>(senderTopic, Ping.newBuilder().setMessage("world").build()));
-        producer.flush();
-        ConsumerRecord<String, Ping> record = KafkaTestUtils.getSingleRecord(consumer, consumerTopic, Durations.FIVE_SECONDS);
+        producer.fromRecords(new ProducerRecord<>(senderTopic, Ping.newBuilder().setMessage("world").build()))
+                .awaitCompletion(Duration.ofSeconds(1));
+        ConsumerRecord<String, Ping> record = consumer.fromTopics(consumerTopic, 1).awaitCompletion(Durations.FIVE_SECONDS)
+                .getFirstRecord();
         assertEquals("5", record.value().getMessage());
     }
 
     @Test
     public void testRetryableException() {
-        producer.send(new ProducerRecord<>(senderTopic, Ping.newBuilder().setMessage("retry-10").build()));
-        producer.flush();
-        ConsumerRecord<String, Ping> record = KafkaTestUtils.getSingleRecord(consumer, consumerTopic, Durations.FIVE_SECONDS);
+        producer.fromRecords(new ProducerRecord<>(senderTopic, Ping.newBuilder().setMessage("retry-10").build()))
+                .awaitCompletion(Duration.ofSeconds(1));
+        ConsumerRecord<String, Ping> record = consumer.fromTopics(consumerTopic, 1).awaitCompletion(Durations.FIVE_SECONDS)
+                .getFirstRecord();
         assertEquals("OK", record.value().getMessage());
     }
 
     @Test
     public void testBigMessage() {
-        producer.send(new ProducerRecord<>(senderTopic, Ping.newBuilder().setMessage("bigMessage-100000").build()));
-        producer.flush();
+        producer.fromRecords(new ProducerRecord<>(senderTopic, Ping.newBuilder().setMessage("bigMessage-100000").build()))
+                .awaitCompletion(Duration.ofSeconds(1));
 
-        ConsumerRecord<String, Ping> record = KafkaTestUtils.getSingleRecord(consumer, consumerTopic, Durations.FIVE_SECONDS);
+        ConsumerRecord<String, Ping> record = consumer.fromTopics(consumerTopic, 1).awaitCompletion(Durations.FIVE_SECONDS)
+                .getFirstRecord();
         assertEquals(100000, record.value().getMessage().getBytes(StandardCharsets.UTF_8).length);
     }
 

--- a/integration-tests/stateful-global/pom.xml
+++ b/integration-tests/stateful-global/pom.xml
@@ -121,8 +121,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.springframework.kafka</groupId>
-      <artifactId>spring-kafka-test</artifactId>
+      <groupId>io.smallrye.reactive</groupId>
+      <artifactId>smallrye-reactive-messaging-kafka-test-companion</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-test-kafka-companion</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/integration-tests/stateful-global/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/stateful/global/PingProcessorQuarkusTest.java
+++ b/integration-tests/stateful-global/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/stateful/global/PingProcessorQuarkusTest.java
@@ -22,36 +22,36 @@ package io.quarkiverse.kafkastreamsprocessor.sample.stateful.global;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 
-import java.util.List;
-import java.util.Map;
+import java.time.Duration;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufDeserializer;
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufSerializer;
 
 import io.quarkiverse.kafkastreamsprocessor.sample.message.PingMessage.Ping;
-import io.quarkiverse.kafkastreamsprocessor.testframework.KafkaBootstrapServers;
-import io.quarkiverse.kafkastreamsprocessor.testframework.QuarkusIntegrationCompatibleKafkaDevServicesResource;
 import io.quarkiverse.kafkastreamsprocessor.testframework.StateDirCleaningResource;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder;
 
 /**
  * Blackbox test that can run both in JVM and native modes (@Inject and @ConfigProperty not allowed)
  */
 @QuarkusTest
 @QuarkusTestResource(value = StateDirCleaningResource.class, restrictToAnnotatedClass = true)
-@QuarkusTestResource(QuarkusIntegrationCompatibleKafkaDevServicesResource.class)
+@QuarkusTestResource(KafkaCompanionResource.class)
 class PingProcessorQuarkusTest {
     String senderTopic = "ping-events";
 
@@ -61,33 +61,23 @@ class PingProcessorQuarkusTest {
 
     String globalTopicCapital = "global-topic-capital";
 
-    KafkaProducer<String, Ping> producerPing;
+    ProducerBuilder<String, Ping> producerPing;
 
-    KafkaProducer<String, String> producerGlobalTopic;
+    ProducerBuilder<String, String> producerGlobalTopic;
 
-    KafkaProducer<String, String> producerGlobalTopicCapital;
+    ConsumerBuilder<String, Ping> consumer;
 
-    KafkaConsumer<String, Ping> consumer;
-
-    @KafkaBootstrapServers
-    String kafkaBootstrapServers;
+    @InjectKafkaCompanion
+    KafkaCompanion companion;
 
     @BeforeEach
     public void setup() {
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(kafkaBootstrapServers, "test", "true");
-
-        consumer = new KafkaConsumer(consumerProps, new StringDeserializer(),
-                new KafkaProtobufDeserializer<>(Ping.parser()));
-        consumer.subscribe(List.of(consumerTopic));
-
-        Map<String, Object> producerProps = KafkaTestUtils.producerProps(kafkaBootstrapServers);
-        producerPing = new KafkaProducer(producerProps, new StringSerializer(),
+        consumer = companion.consumeWithDeserializers(new StringDeserializer(),
+                new KafkaProtobufDeserializer<>(Ping.parser())).withGroupId("test")
+                .withOffsetReset(OffsetResetStrategy.EARLIEST.toString()).withAutoCommit();
+        producerPing = companion.produceWithSerializers(new StringSerializer(),
                 new KafkaProtobufSerializer<>());
-
-        producerGlobalTopic = new KafkaProducer<>(producerProps, new StringSerializer(),
-                new StringSerializer());
-
-        producerGlobalTopicCapital = new KafkaProducer<>(producerProps, new StringSerializer(),
+        producerGlobalTopic = companion.produceWithSerializers(new StringSerializer(),
                 new StringSerializer());
     }
 
@@ -95,38 +85,47 @@ class PingProcessorQuarkusTest {
     public void tearDown() {
         producerPing.close();
         producerGlobalTopic.close();
-        producerGlobalTopicCapital.close();
         consumer.close();
     }
 
     @Test
     void testGlobalStoreValueRetrieval() throws InterruptedException {
-        producerPing.send(new ProducerRecord<>(senderTopic, "ID1", Ping.newBuilder().setMessage("whatever").build()));
-        ConsumerRecord<String, Ping> receivedRecord = KafkaTestUtils.getSingleRecord(consumer, consumerTopic);
+        producerPing.fromRecords(new ProducerRecord<>(senderTopic, "ID1", Ping.newBuilder().setMessage("whatever").build()))
+                .awaitCompletion(Duration.ofSeconds(1));
+        ConsumerRecord<String, Ping> receivedRecord = consumer.fromTopics(consumerTopic, 1)
+                .awaitCompletion(Duration.ofSeconds(5)).getFirstRecord();
         assertThat(receivedRecord.value().getMessage(), containsString("Stored value for ID1 is null"));
 
         // Store two values using the two global topics
-        producerGlobalTopic.send(new ProducerRecord<>(globalTopic, "ID1", "dont-capitalize-me"));
-        producerGlobalTopicCapital.send(new ProducerRecord<>(globalTopicCapital, "ID1", "capitalize-me"));
+        producerGlobalTopic.fromRecords(new ProducerRecord<>(globalTopic, "ID1", "dont-capitalize-me"))
+                .awaitCompletion(Duration.ofSeconds(1));
+        producerGlobalTopic.fromRecords(new ProducerRecord<>(globalTopicCapital, "ID1", "capitalize-me"))
+                .awaitCompletion(Duration.ofSeconds(1));
         Thread.sleep(1000L);
-        producerPing.send(new ProducerRecord<>(senderTopic, "ID1", Ping.newBuilder().setMessage("whatever").build()));
-        receivedRecord = KafkaTestUtils.getSingleRecord(consumer, consumerTopic);
+        producerPing.fromRecords(new ProducerRecord<>(senderTopic, "ID1", Ping.newBuilder().setMessage("whatever").build()))
+                .awaitCompletion(Duration.ofSeconds(1));
+        receivedRecord = consumer.fromTopics(consumerTopic, 1).awaitCompletion(Duration.ofSeconds(5)).getFirstRecord();
         // Check that the value has been stored in the global store
         assertThat(receivedRecord.value().getMessage(),
                 containsString("Stored value for ID1 is dont-capitalize-me and capitalized value is CAPITALIZE-ME"));
 
         // Check that the value still exists in the global store
-        producerPing.send(new ProducerRecord<>(senderTopic, "ID1", Ping.newBuilder().setMessage("whatever").build()));
-        receivedRecord = KafkaTestUtils.getSingleRecord(consumer, consumerTopic);
+        producerPing.fromRecords(new ProducerRecord<>(senderTopic, "ID1", Ping.newBuilder().setMessage("whatever").build()))
+                .awaitCompletion(Duration.ofSeconds(1));
+        Thread.sleep(1000L);
+        receivedRecord = consumer.fromTopics(consumerTopic, 1).awaitCompletion(Duration.ofSeconds(5)).getFirstRecord();
         assertThat(receivedRecord.value().getMessage(),
                 containsString("Stored value for ID1 is dont-capitalize-me and capitalized value is CAPITALIZE-ME"));
 
         // Store two new values using the two global topics
-        producerGlobalTopic.send(new ProducerRecord<>(globalTopic, "ID1", "dont-capitalize-me-2"));
-        producerGlobalTopicCapital.send(new ProducerRecord<>(globalTopicCapital, "ID1", "capitalize-me-2"));
+        producerGlobalTopic.fromRecords(new ProducerRecord<>(globalTopic, "ID1", "dont-capitalize-me-2"))
+                .awaitCompletion(Duration.ofSeconds(1));
+        producerGlobalTopic.fromRecords(new ProducerRecord<>(globalTopicCapital, "ID1", "capitalize-me-2"))
+                .awaitCompletion(Duration.ofSeconds(1));
         Thread.sleep(1000L);
-        producerPing.send(new ProducerRecord<>(senderTopic, "ID1", Ping.newBuilder().setMessage("whatever").build()));
-        receivedRecord = KafkaTestUtils.getSingleRecord(consumer, consumerTopic);
+        producerPing.fromRecords(new ProducerRecord<>(senderTopic, "ID1", Ping.newBuilder().setMessage("whatever").build()))
+                .awaitCompletion(Duration.ofSeconds(1));
+        receivedRecord = consumer.fromTopics(consumerTopic, 1).awaitCompletion(Duration.ofSeconds(5)).getFirstRecord();
         // Check that the value has been stored in the global store
         assertThat(receivedRecord.value().getMessage(),
                 containsString("Stored value for ID1 is dont-capitalize-me-2 and capitalized value is CAPITALIZE-ME-2"));

--- a/integration-tests/stateful-global/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/stateful/global/TracingGlobalProcessorQuarkusTest.java
+++ b/integration-tests/stateful-global/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/stateful/global/TracingGlobalProcessorQuarkusTest.java
@@ -1,17 +1,15 @@
 package io.quarkiverse.kafkastreamsprocessor.sample.stateful.global;
 
-import java.util.Map;
+import java.time.Duration;
 
 import jakarta.inject.Inject;
 
-import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
@@ -21,23 +19,25 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.testing.assertj.TracesAssert;
 import io.quarkiverse.kafkastreamsprocessor.propagation.KafkaTextMapSetter;
-import io.quarkiverse.kafkastreamsprocessor.testframework.KafkaBootstrapServers;
-import io.quarkiverse.kafkastreamsprocessor.testframework.QuarkusIntegrationCompatibleKafkaDevServicesResource;
 import io.quarkiverse.kafkastreamsprocessor.testframework.StateDirCleaningResource;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder;
 
 @QuarkusTest
 @QuarkusTestResource(value = StateDirCleaningResource.class, restrictToAnnotatedClass = true)
-@QuarkusTestResource(QuarkusIntegrationCompatibleKafkaDevServicesResource.class)
+@QuarkusTestResource(KafkaCompanionResource.class)
 public class TracingGlobalProcessorQuarkusTest {
 
     String globalTopicCapital = "global-topic-capital";
 
-    KafkaProducer<String, String> producerGlobalTopicCapital;
+    ProducerBuilder<String, String> producerGlobalTopicCapital;
 
-    @KafkaBootstrapServers
-    String kafkaBootstrapServers;
+    @InjectKafkaCompanion
+    KafkaCompanion companion;
 
     @Inject
     OpenTelemetry openTelemetry;
@@ -53,11 +53,7 @@ public class TracingGlobalProcessorQuarkusTest {
 
     @BeforeEach
     public void setup() {
-        Map<String, Object> producerProps = KafkaTestUtils.producerProps(kafkaBootstrapServers);
-
-        producerGlobalTopicCapital = new KafkaProducer<>(producerProps, new StringSerializer(),
-                new StringSerializer());
-
+        producerGlobalTopicCapital = companion.produceWithSerializers(new StringSerializer(), new StringSerializer());
         clearSpans();
     }
 
@@ -77,7 +73,8 @@ public class TracingGlobalProcessorQuarkusTest {
 
             Thread.sleep(1000L);
 
-            producerGlobalTopicCapital.send(new ProducerRecord<>(globalTopicCapital, 0, "ID1", "capitalize-me", headers));
+            producerGlobalTopicCapital.fromRecords(new ProducerRecord<>(globalTopicCapital, 0, "ID1", "capitalize-me", headers))
+                    .awaitCompletion(Duration.ofSeconds(1));
 
             Thread.sleep(1000L);
         } finally {

--- a/integration-tests/stateful/pom.xml
+++ b/integration-tests/stateful/pom.xml
@@ -121,8 +121,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.springframework.kafka</groupId>
-      <artifactId>spring-kafka-test</artifactId>
+      <groupId>io.smallrye.reactive</groupId>
+      <artifactId>smallrye-reactive-messaging-kafka-test-companion</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-test-kafka-companion</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/integration-tests/stateful/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/stateful/PingProcessorQuarkusTest.java
+++ b/integration-tests/stateful/src/test/java/io/quarkiverse/kafkastreamsprocessor/sample/stateful/PingProcessorQuarkusTest.java
@@ -25,17 +25,15 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import jakarta.inject.Inject;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -44,24 +42,26 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufDeserializer;
 import com.github.daniel.shuy.kafka.protobuf.serde.KafkaProtobufSerializer;
 
 import io.quarkiverse.kafkastreamsprocessor.sample.message.PingMessage.Ping;
-import io.quarkiverse.kafkastreamsprocessor.testframework.KafkaBootstrapServers;
-import io.quarkiverse.kafkastreamsprocessor.testframework.QuarkusIntegrationCompatibleKafkaDevServicesResource;
 import io.quarkiverse.kafkastreamsprocessor.testframework.StateDirCleaningResource;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kafka.InjectKafkaCompanion;
+import io.quarkus.test.kafka.KafkaCompanionResource;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder;
+import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
+import io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder;
 
 /**
  * Blackbox test that can run both in JVM and native modes (@Inject and @ConfigProperty not allowed)
  */
 @QuarkusTest
 @QuarkusTestResource(StateDirCleaningResource.class)
-@QuarkusTestResource(QuarkusIntegrationCompatibleKafkaDevServicesResource.class)
+@QuarkusTestResource(KafkaCompanionResource.class)
 class PingProcessorQuarkusTest {
     String senderTopic = "ping-events";
 
@@ -69,24 +69,19 @@ class PingProcessorQuarkusTest {
 
     String storeTopic = "stateful-sample-ping-data-changelog";
 
-    KafkaProducer<String, Ping> producer;
+    ProducerBuilder<String, Ping> producer;
 
-    KafkaConsumer<String, Ping> consumer;
+    ConsumerBuilder<String, Ping> consumer;
 
-    @KafkaBootstrapServers
-    String kafkaBootstrapServers;
+    @InjectKafkaCompanion
+    KafkaCompanion companion;
 
     @BeforeEach
     public void setup() throws IOException {
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(kafkaBootstrapServers, "test", "true");
-
-        consumer = new KafkaConsumer(consumerProps, new StringDeserializer(),
-                new KafkaProtobufDeserializer<>(Ping.parser()));
-        consumer.subscribe(List.of(consumerTopic));
-
-        Map<String, Object> producerProps = KafkaTestUtils.producerProps(kafkaBootstrapServers);
-        producer = new KafkaProducer(producerProps, new StringSerializer(),
-                new KafkaProtobufSerializer<>());
+        consumer = companion.consumeWithDeserializers(new StringDeserializer(),
+                new KafkaProtobufDeserializer<>(Ping.parser())).withGroupId("test")
+                .withOffsetReset(OffsetResetStrategy.EARLIEST.toString()).withAutoCommit();
+        producer = companion.produceWithSerializers(new StringSerializer(), new KafkaProtobufSerializer<>());
     }
 
     @AfterEach
@@ -97,21 +92,26 @@ class PingProcessorQuarkusTest {
 
     @Test
     void testHistory() throws Exception {
-        producer.send(new ProducerRecord<>(senderTopic, "ID1", Ping.newBuilder().setMessage("value1").build()));
+        producer.fromRecords(new ProducerRecord<>(senderTopic, "ID1", Ping.newBuilder().setMessage("value1").build()))
+                .awaitCompletion(Duration.ofSeconds(1));
         // forcing 1 millisecond between each message so the DuplicateValuesPunctuator is executed at every message
         // reception
         Thread.sleep(1L);
-        producer.send(new ProducerRecord<>(senderTopic, "ID2", Ping.newBuilder().setMessage("value1").build()));
+        producer.fromRecords(new ProducerRecord<>(senderTopic, "ID2", Ping.newBuilder().setMessage("value1").build()))
+                .awaitCompletion(Duration.ofSeconds(1));
         Thread.sleep(1L);
-        producer.send(new ProducerRecord<>(senderTopic, "ID1", Ping.newBuilder().setMessage("value2").build()));
+        producer.fromRecords(new ProducerRecord<>(senderTopic, "ID1", Ping.newBuilder().setMessage("value2").build()))
+                .awaitCompletion(Duration.ofSeconds(1));
         Thread.sleep(1L);
-        producer.send(new ProducerRecord<>(senderTopic, "ID1", Ping.newBuilder().setMessage("value3").build()));
+        producer.fromRecords(new ProducerRecord<>(senderTopic, "ID1", Ping.newBuilder().setMessage("value3").build()))
+                .awaitCompletion(Duration.ofSeconds(1));
         Thread.sleep(1L);
-        producer.send(new ProducerRecord<>(senderTopic, "ID2", Ping.newBuilder().setMessage("value2").build()));
+        producer.fromRecords(new ProducerRecord<>(senderTopic, "ID2", Ping.newBuilder().setMessage("value2").build()))
+                .awaitCompletion(Duration.ofSeconds(1));
         Thread.sleep(1L);
-        producer.flush();
 
-        ConsumerRecords<String, Ping> records = KafkaTestUtils.getRecords(consumer, Durations.TEN_SECONDS, 5);
+        List<ConsumerRecord<String, Ping>> records = consumer.fromTopics(consumerTopic, 5)
+                .awaitCompletion(Durations.TEN_SECONDS).getRecords();
         assertThat(
                 StreamSupport.stream(records.spliterator(), false)
                         .map(ConsumerRecord::value)

--- a/test-framework/src/main/java/io/quarkiverse/kafkastreamsprocessor/testframework/KafkaBootstrapServers.java
+++ b/test-framework/src/main/java/io/quarkiverse/kafkastreamsprocessor/testframework/KafkaBootstrapServers.java
@@ -24,7 +24,12 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * @deprecated Please use KafkaCompanionResource from
+ *             <a href="https://quarkus.io/guides/kafka#testing-using-a-kafka-broker">quarkus-test-kafka-companion</a>
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.FIELD })
+@Deprecated(since = "7.0", forRemoval = true)
 public @interface KafkaBootstrapServers {
 }

--- a/test-framework/src/main/java/io/quarkiverse/kafkastreamsprocessor/testframework/QuarkusIntegrationCompatibleKafkaDevServicesResource.java
+++ b/test-framework/src/main/java/io/quarkiverse/kafkastreamsprocessor/testframework/QuarkusIntegrationCompatibleKafkaDevServicesResource.java
@@ -28,8 +28,12 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * Lifecycle Manager to plug with @QuarkusTestResource that allows access to the kafka dev service even in a
  * QuarkusIntegrationTest.
+ *
+ * @deprecated Please use KafkaCompanionResource from
+ *             <a href="https://quarkus.io/guides/kafka#testing-using-a-kafka-broker">quarkus-test-kafka-companion</a>
  */
 @Slf4j
+@Deprecated(since = "7.0", forRemoval = true)
 public class QuarkusIntegrationCompatibleKafkaDevServicesResource
         implements QuarkusTestResourceLifecycleManager, DevServicesContext.ContextAware {
     String kafkaBootstrapServers;


### PR DESCRIPTION
KafkaCompanion is a test utility class provided by [smallrye-reactive-messaging-kafka](https://smallrye.io/smallrye-reactive-messaging/4.34.0/kafka/test-companion/). There is an associated [Quarkus extension](https://quarkus.io/guides/kafka#testing-using-a-kafka-broker), which usage has been documented. In this PR we adopt the test utility class, which replaces spring-kafka-test entirely. Advantages are that in the long run we no more need to maintain an alignment between the versions of Kafka client libraries that Quarkus is using, and those with which spring-kafka-test is packaged.