### PR TITLE
chore(deps): Make main compatible with Quarkus 3.38

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse.kafkastreamsprocessor</groupId>
     <artifactId>quarkus-kafka-streams-processor-parent</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>quarkus-kafka-streams-processor-api</artifactId>
   <name>quarkus-kafka-streams-processor-api</name>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -4,13 +4,13 @@
   <parent>
     <groupId>io.quarkiverse.kafkastreamsprocessor</groupId>
     <artifactId>quarkus-kafka-streams-processor-bom-parent</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>quarkus-kafka-streams-processor-bom</artifactId>
   <name>quarkus-kafka-streams-processor-bom</name>
   <packaging>pom</packaging>
   <properties>
-    <quarkus-kafka-streams-processor.version>6.0.0-SNAPSHOT</quarkus-kafka-streams-processor.version>
+    <quarkus-kafka-streams-processor.version>6.1.0-SNAPSHOT</quarkus-kafka-streams-processor.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse.kafkastreamsprocessor</groupId>
     <artifactId>quarkus-kafka-streams-processor-parent</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>quarkus-kafka-streams-processor-bom-parent</artifactId>
   <name>quarkus-kafka-streams-processor-bom-parent</name>

--- a/bom/test/pom.xml
+++ b/bom/test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse.kafkastreamsprocessor</groupId>
     <artifactId>quarkus-kafka-streams-processor-bom-parent</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>quarkus-kafka-streams-processor-test-bom</artifactId>
   <name>quarkus-kafka-streams-processor-test-bom</name>

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse.kafkastreamsprocessor</groupId>
     <artifactId>quarkus-kafka-streams-processor-parent</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>quarkus-kafka-streams-processor-deployment</artifactId>
   <name>quarkus-kafka-streams-processor-deployment</name>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkiverse.kafkastreamsprocessor</groupId>
         <artifactId>quarkus-kafka-streams-processor-parent</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse.kafkastreamsprocessor</groupId>
     <artifactId>quarkus-kafka-streams-processor-parent</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>quarkus-kafka-streams-processor-impl</artifactId>
   <name>quarkus-kafka-streams-processor-impl</name>

--- a/integration-tests/consumer/pom.xml
+++ b/integration-tests/consumer/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.quarkiverse.kafkastreamsprocessor</groupId>
         <artifactId>quarkus-kafka-streams-processor-integration-tests</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/custom-serde/pom.xml
+++ b/integration-tests/custom-serde/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.quarkiverse.kafkastreamsprocessor</groupId>
     <artifactId>quarkus-kafka-streams-processor-integration-tests</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/edition-2024-generated/pom.xml
+++ b/integration-tests/edition-2024-generated/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.quarkiverse.kafkastreamsprocessor</groupId>
     <artifactId>quarkus-kafka-streams-processor-integration-tests</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/json-pojo/pom.xml
+++ b/integration-tests/json-pojo/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.quarkiverse.kafkastreamsprocessor</groupId>
     <artifactId>quarkus-kafka-streams-processor-integration-tests</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/kafka-to-rest/pom.xml
+++ b/integration-tests/kafka-to-rest/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.quarkiverse.kafkastreamsprocessor</groupId>
     <artifactId>quarkus-kafka-streams-processor-integration-tests</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/multioutput/pom.xml
+++ b/integration-tests/multioutput/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.quarkiverse.kafkastreamsprocessor</groupId>
     <artifactId>quarkus-kafka-streams-processor-integration-tests</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse.kafkastreamsprocessor</groupId>
     <artifactId>quarkus-kafka-streams-processor-parent</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>quarkus-kafka-streams-processor-integration-tests</artifactId>
   <name>quarkus-kafka-streams-processor-integration-tests</name>

--- a/integration-tests/proto-3-generated/pom.xml
+++ b/integration-tests/proto-3-generated/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.quarkiverse.kafkastreamsprocessor</groupId>
     <artifactId>quarkus-kafka-streams-processor-integration-tests</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/protobuf-binding-edition-2024/pom.xml
+++ b/integration-tests/protobuf-binding-edition-2024/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.quarkiverse.kafkastreamsprocessor</groupId>
     <artifactId>quarkus-kafka-streams-processor-integration-tests</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/protobuf-binding-protoc-3/pom.xml
+++ b/integration-tests/protobuf-binding-protoc-3/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.quarkiverse.kafkastreamsprocessor</groupId>
     <artifactId>quarkus-kafka-streams-processor-integration-tests</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/protobuf-binding/pom.xml
+++ b/integration-tests/protobuf-binding/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.quarkiverse.kafkastreamsprocessor</groupId>
     <artifactId>quarkus-kafka-streams-processor-integration-tests</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/simple/pom.xml
+++ b/integration-tests/simple/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.quarkiverse.kafkastreamsprocessor</groupId>
     <artifactId>quarkus-kafka-streams-processor-integration-tests</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/stateful-global/pom.xml
+++ b/integration-tests/stateful-global/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse.kafkastreamsprocessor</groupId>
     <artifactId>quarkus-kafka-streams-processor-integration-tests</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/stateful/pom.xml
+++ b/integration-tests/stateful/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse.kafkastreamsprocessor</groupId>
     <artifactId>quarkus-kafka-streams-processor-integration-tests</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <groupId>io.quarkiverse.kafkastreamsprocessor</groupId>
   <artifactId>quarkus-kafka-streams-processor-parent</artifactId>
   <name>quarkus-kafka-streams-processor-parent</name>
-  <version>6.0.0-SNAPSHOT</version>
+  <version>6.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <modules>
     <module>bom</module>
@@ -28,8 +28,9 @@
     <tag>HEAD</tag>
   </scm>
   <properties>
-    <quarkus.version>3.37.0</quarkus.version>
+    <quarkus.version>3.38.0</quarkus.version>
     <protobuf.version>4.32.1</protobuf.version>
+    <lombok.version>1.18.46</lombok.version>
   </properties>
 
   <repositories>
@@ -51,6 +52,11 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.projectlombok</groupId>
+        <artifactId>lombok</artifactId>
+        <version>${lombok.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <build>
@@ -67,6 +73,13 @@
             <compilerArgs>
               <arg>-parameters</arg>
             </compilerArgs>
+            <annotationProcessorPaths>
+              <annotationProcessorPath>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>${lombok.version}</version>
+              </annotationProcessorPath>
+            </annotationProcessorPaths>
           </configuration>
         </plugin>
         <plugin>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse.kafkastreamsprocessor</groupId>
     <artifactId>quarkus-kafka-streams-processor-parent</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>quarkus-kafka-streams-processor</artifactId>
   <name>quarkus-kafka-streams-processor</name>

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse.kafkastreamsprocessor</groupId>
     <artifactId>quarkus-kafka-streams-processor-parent</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>quarkus-kafka-streams-processor-spi</artifactId>
   <name>quarkus-kafka-streams-processor-spi</name>

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse.kafkastreamsprocessor</groupId>
     <artifactId>quarkus-kafka-streams-processor-parent</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>quarkus-kafka-streams-processor-test-framework</artifactId>
   <name>quarkus-kafka-streams-processor-test-framework</name>

--- a/test-framework/src/test/java/io/quarkiverse.kafkastreamsprocessor.testframework/QuarkusIntegrationCompatibleKafkaDevServicesResourceTest.java
+++ b/test-framework/src/test/java/io/quarkiverse.kafkastreamsprocessor.testframework/QuarkusIntegrationCompatibleKafkaDevServicesResourceTest.java
@@ -35,8 +35,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import io.quarkus.runtime.ValueRegistryImpl;
 import io.quarkus.test.common.DevServicesContext;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.quarkus.value.registry.ValueRegistry;
 
 @ExtendWith(MockitoExtension.class)
 class QuarkusIntegrationCompatibleKafkaDevServicesResourceTest {
@@ -94,6 +96,11 @@ class QuarkusIntegrationCompatibleKafkaDevServicesResourceTest {
 
         DefaultTestInjectorCopy(Object testInstance) {
             this.testInstance = testInstance;
+        }
+
+        @Override
+        public ValueRegistry valueRegistry() {
+            return ValueRegistryImpl.builder().build();
         }
 
         @Override

--- a/text-map-accessors/pom.xml
+++ b/text-map-accessors/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse.kafkastreamsprocessor</groupId>
     <artifactId>quarkus-kafka-streams-processor-parent</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>quarkus-kafka-streams-processor-text-map-accessors</artifactId>
   <name>quarkus-kafka-streams-processor-text-map-accessors</name>


### PR DESCRIPTION
The nightly Quarkus ecosystem CI build is failing because of changes coming from Quarkus 3.38. This PR does update the quarkus.version to 3.38.0.

Biggest impact is on the test of a QuarkusTestResourceLifecycleManager.

Versions in POMs pushed to 6.1 to mark the difference with 6.0.